### PR TITLE
Fix main logging reference and build script output

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -43,6 +43,12 @@ echo [4/8] Tool versions:
 for /f "delims=" %%i in ('cmake --version ^| findstr /B /C:"cmake version"') do echo   - %%i
 for /f "delims=" %%i in ('zig version') do echo   - zig %%i
 for /f "delims=" %%i in ('cargo --version') do echo   - %%i
+cargo-zigbuild --version >nul 2>&1
+if errorlevel 1 (
+  echo   - cargo-zigbuild not found
+) else (
+  for /f "delims=" %%i in ('cargo-zigbuild --version') do echo   - %%i
+)
 for /f "delims=" %%i in ('rustc --version') do echo   - %%i
 rustup --version >nul 2>&1
 if errorlevel 1 (

--- a/build.ps1
+++ b/build.ps1
@@ -73,6 +73,11 @@ Get-CommandOutput 'cmake' @('--version') |
     ForEach-Object { Write-Host "  - $_" }
 Get-CommandOutput 'zig' @('version') | ForEach-Object { Write-Host "  - zig $_" }
 Get-CommandOutput 'cargo' @('--version') | ForEach-Object { Write-Host "  - $_" }
+try {
+    Get-CommandOutput 'cargo-zigbuild' @('--version') | ForEach-Object { Write-Host "  - $_" }
+} catch {
+    Write-Host '  - cargo-zigbuild not found'
+}
 Get-CommandOutput 'rustc' @('--version') | ForEach-Object { Write-Host "  - $_" }
 if (Test-CommandExists 'rustup') {
     $rustupVersion = cmd /c "rustup --version 2>nul"

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let allocator_tuning = core::util::diagnostics::tune_allocator_for_long_running_process();
 
     #[cfg(all(target_os = "linux", target_env = "musl"))]
-    logging::info_file_async(
+    core::logging::info_file_async(
         "allocator profile: mimalloc (musl target), purge_delay=0, purge_decommits=1, thp=0, large_os_pages=0, arena_eager_commit=0"
             .to_string(),
     );


### PR DESCRIPTION
## Purpose
- Fix the musl/mimalloc startup logging path in `src/main.rs` so it resolves through `core::logging`.
- Include `cargo-zigbuild` in Windows build script tool version output.

## Affected modules
- `src/main.rs`
- `build.ps1`
- `build.bat`

## Verification
- `cargo check`
- `cargo zigbuild --target aarch64-unknown-linux-musl --release`