### PR TITLE
refactor: ddd phase 6 - expand anti-corruption layer to delisted, qfii, and etf tasks

### DIFF
--- a/src/app/backfill/acl.rs
+++ b/src/app/backfill/acl.rs
@@ -2,6 +2,7 @@
 //!
 //! 用於隔離外部爬蟲資料結構（Crawler DTO）與應用層/領域層之業務邏輯命令或實體。
 
+use crate::infra::crawler::share::EtfInfo;
 use crate::infra::crawler::twse::international_securities_identification_number::InternationalSecuritiesIdentificationNumber;
 use crate::infra::crawler::twse::suspend_listing::SuspendListing;
 use crate::infra::database::table::stock::extension::qualified_foreign_institutional_investor::QualifiedForeignInstitutionalInvestor;
@@ -107,6 +108,21 @@ impl QfiiAclMapper {
     }
 }
 
+/// ETF 爬蟲資料防腐層轉譯器。
+pub struct EtfAclMapper;
+
+impl EtfAclMapper {
+    /// 將原始 ETF DTO 轉譯成 `RegisterStockCommand`。
+    pub fn to_registration_command(dto: &EtfInfo) -> RegisterStockCommand {
+        RegisterStockCommand {
+            symbol: dto.stock_symbol.clone(),
+            name: dto.name.clone(),
+            market_id: dto.exchange_market.stock_exchange_market_id,
+            industry_id: dto.industry_id,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -203,5 +219,23 @@ mod tests {
         assert_eq!(cmd.shares_held, 50000);
         assert_eq!(cmd.share_holding_percentage, dec!(75.5));
         assert_eq!(cmd.issued_share, 100000);
+    }
+
+    #[test]
+    fn test_etf_to_registration_command() {
+        let etf = EtfInfo {
+            stock_symbol: "0050".to_string(),
+            name: "元大台灣50".to_string(),
+            listing_date: "2003/06/30".to_string(),
+            industry: "ETF".to_string(),
+            exchange_market: StockExchangeMarket::new(2, 1),
+            industry_id: 9001,
+        };
+
+        let cmd = EtfAclMapper::to_registration_command(&etf);
+        assert_eq!(cmd.symbol, "0050");
+        assert_eq!(cmd.name, "元大台灣50");
+        assert_eq!(cmd.market_id, 2);
+        assert_eq!(cmd.industry_id, 9001);
     }
 }

--- a/src/app/backfill/acl.rs
+++ b/src/app/backfill/acl.rs
@@ -3,6 +3,9 @@
 //! 用於隔離外部爬蟲資料結構（Crawler DTO）與應用層/領域層之業務邏輯命令或實體。
 
 use crate::infra::crawler::twse::international_securities_identification_number::InternationalSecuritiesIdentificationNumber;
+use crate::infra::crawler::twse::suspend_listing::SuspendListing;
+use crate::infra::database::table::stock::extension::qualified_foreign_institutional_investor::QualifiedForeignInstitutionalInvestor;
+use rust_decimal::Decimal;
 
 /// 註冊或變更證券識別資料命令。
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -15,6 +18,26 @@ pub struct RegisterStockCommand {
     pub market_id: i32,
     /// 產業分類 ID
     pub industry_id: i32,
+}
+
+/// 終止上市 (下市) 處理命令。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DelistedCompanyCommand {
+    /// 證券代號
+    pub symbol: String,
+}
+
+/// 外資持股狀態更新命令。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateQfiiCommand {
+    /// 證券代號
+    pub symbol: String,
+    /// 外資持有股數
+    pub shares_held: i64,
+    /// 外資持股比率
+    pub share_holding_percentage: Decimal,
+    /// 已發行股數
+    pub issued_share: i64,
 }
 
 /// ISIN 爬蟲資料防腐層轉譯器。
@@ -43,10 +66,52 @@ impl IsinAclMapper {
     }
 }
 
+/// 下市公司爬蟲資料防腐層轉譯器。
+pub struct DelistedCompanyAclMapper;
+
+impl DelistedCompanyAclMapper {
+    /// 將下市公司原始 DTO 轉譯成 `DelistedCompanyCommand`。
+    ///
+    /// # 資料清洗與過濾
+    /// - 若下市日期格式無效（長度小於 3），回傳 `None`。
+    /// - 過濾掉民國 110 年之前的下市資料，以縮小回補與更新範圍。
+    pub fn to_delisted_command(dto: &SuspendListing) -> Option<DelistedCompanyCommand> {
+        if dto.delisting_date.len() < 3 {
+            return None;
+        }
+
+        // 擷取民國年前 3 碼並解析為整數
+        let year = dto.delisting_date[..3].parse::<i32>().ok()?;
+        if year < 110 {
+            return None;
+        }
+
+        Some(DelistedCompanyCommand {
+            symbol: dto.stock_symbol.clone(),
+        })
+    }
+}
+
+/// 外資持股爬蟲資料防腐層轉譯器。
+pub struct QfiiAclMapper;
+
+impl QfiiAclMapper {
+    /// 將原始的外資持股資料轉譯成系統內部的 `UpdateQfiiCommand`。
+    pub fn to_update_command(dto: &QualifiedForeignInstitutionalInvestor) -> UpdateQfiiCommand {
+        UpdateQfiiCommand {
+            symbol: dto.stock_symbol.clone(),
+            shares_held: dto.qfii_shares_held,
+            share_holding_percentage: dto.qfii_share_holding_percentage,
+            issued_share: dto.issued_share,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::infra::database::table::stock_exchange_market::StockExchangeMarket;
+    use rust_decimal_macros::dec;
 
     #[test]
     fn test_to_registration_command_success() {
@@ -80,10 +145,63 @@ mod tests {
             industry: "ETF".to_string(),
             cfi_code: "CEOGEU".to_string(),
             exchange_market: StockExchangeMarket::new(2, 1),
-            industry_id: 0, // 設為無效的 0
+            industry_id: 0,
         };
 
         let cmd = IsinAclMapper::to_registration_command(&isin);
         assert!(cmd.is_none());
+    }
+
+    #[test]
+    fn test_to_delisted_command_success() {
+        let dto = SuspendListing {
+            delisting_date: "1120520".to_string(),
+            name: "測試下市".to_string(),
+            stock_symbol: "9999".to_string(),
+        };
+
+        let cmd = DelistedCompanyAclMapper::to_delisted_command(&dto);
+        assert!(cmd.is_some());
+        assert_eq!(cmd.unwrap().symbol, "9999");
+    }
+
+    #[test]
+    fn test_to_delisted_command_too_old() {
+        let dto = SuspendListing {
+            delisting_date: "1091231".to_string(),
+            name: "測試老舊下市".to_string(),
+            stock_symbol: "9999".to_string(),
+        };
+
+        let cmd = DelistedCompanyAclMapper::to_delisted_command(&dto);
+        assert!(cmd.is_none(), "應過濾掉民國 110 年之前的下市資料");
+    }
+
+    #[test]
+    fn test_to_delisted_command_invalid_date() {
+        let dto = SuspendListing {
+            delisting_date: "12".to_string(),
+            name: "無效日期".to_string(),
+            stock_symbol: "9999".to_string(),
+        };
+
+        let cmd = DelistedCompanyAclMapper::to_delisted_command(&dto);
+        assert!(cmd.is_none(), "日期太短應過濾");
+    }
+
+    #[test]
+    fn test_qfii_to_update_command() {
+        let dto = QualifiedForeignInstitutionalInvestor::new(
+            "2330".to_string(),
+            100000,
+            50000,
+            dec!(75.5),
+        );
+
+        let cmd = QfiiAclMapper::to_update_command(&dto);
+        assert_eq!(cmd.symbol, "2330");
+        assert_eq!(cmd.shares_held, 50000);
+        assert_eq!(cmd.share_holding_percentage, dec!(75.5));
+        assert_eq!(cmd.issued_share, 100000);
     }
 }

--- a/src/app/backfill/delisted_company.rs
+++ b/src/app/backfill/delisted_company.rs
@@ -1,6 +1,7 @@
 use crate::{
-    core::logging, core::util::datetime::Weekend, domain::registry::repository::StockRepository,
-    infra::crawler::twse, infra::database::repository::stock::PgStockRepository,
+    app::backfill::acl::DelistedCompanyAclMapper, core::logging, core::util::datetime::Weekend,
+    domain::registry::repository::StockRepository, infra::crawler::twse,
+    infra::database::repository::stock::PgStockRepository,
 };
 use anyhow::Result;
 use chrono::Local;
@@ -16,44 +17,26 @@ pub async fn execute() -> Result<()> {
        logging::info_file_async("更新下市的股票結束");
     }
     let delisted = twse::suspend_listing::visit().await?;
-    let mut items_to_update = Vec::new();
     let repo = PgStockRepository::new();
 
     for company in delisted {
-        if let Some(stock) = repo.find_by_symbol(&company.stock_symbol).await? {
-            if stock.suspend_listing() {
-                //println!("已下市{:?}",stock);
-                continue;
-            }
-
-            if company.delisting_date.len() < 3 {
-                continue;
-            }
-
-            let year = match company.delisting_date[..3].parse::<i32>() {
-                Ok(_year) => _year,
-                Err(why) => {
-                    logging::error_file_async(format!("轉換資料日期發生錯誤. because {:?}", why));
+        // 透過防腐層轉譯為內部命令，內含格式與民國年分過濾邏輯
+        if let Some(cmd) = DelistedCompanyAclMapper::to_delisted_command(&company) {
+            if let Some(stock) = repo.find_by_symbol(&cmd.symbol).await? {
+                if stock.suspend_listing() {
                     continue;
                 }
-            };
 
-            if year < 110 {
-                continue;
+                let mut another = stock.clone();
+                another.update_suspension(true);
+
+                if let Err(why) = repo.save(&another).await {
+                    logging::error_file_async(format!(
+                        "Failed to update_suspend_listing because {:?}",
+                        why
+                    ));
+                }
             }
-
-            let mut another = stock.clone();
-            another.update_suspension(true);
-            items_to_update.push(another);
-        }
-    }
-
-    for stock in items_to_update {
-        if let Err(why) = repo.save(&stock).await {
-            logging::error_file_async(format!(
-                "Failed to update_suspend_listing because {:?}",
-                why
-            ));
         }
     }
 

--- a/src/app/backfill/etf.rs
+++ b/src/app/backfill/etf.rs
@@ -1,18 +1,12 @@
-use std::fmt::Write;
-
 use crate::{
     app::backfill,
-    core::declare::StockExchangeMarket,
+    app::backfill::acl::EtfAclMapper,
     core::logging,
     core::util::datetime::Weekend,
-    infra::cache::SHARE,
     infra::crawler::{share::EtfInfo, tpex, twse},
-    interfaces::bot,
-    interfaces::bot::telegram::Telegram,
-    interfaces::rpc,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use chrono::Local;
 use scopeguard::defer;
 
@@ -43,15 +37,8 @@ pub async fn execute() -> Result<()> {
 }
 
 /// 批次更新股票資訊到資料庫。
-///
-/// 此函式接收一個 ETF 資訊列表，並逐一檢查是否需要寫入資料庫。
 async fn update_stocks(items: Vec<EtfInfo>) -> Result<()> {
-    // 預分配一個 1024 字元的字串，用來累積要發送給 Telegram 的變動訊息
-    let mut to_bot_msg = String::with_capacity(1024);
-
-    // 遍歷所有傳入的 ETF 項目
     for item in items {
-        // 從系統快取 (SHARE) 中查詢該股票代號，比對現有資料。
         let is_new_or_changed = backfill::is_stock_identity_new_or_changed(
             &item.stock_symbol,
             item.industry_id,
@@ -60,11 +47,9 @@ async fn update_stocks(items: Vec<EtfInfo>) -> Result<()> {
         )
         .await;
 
-        // 如果確認是新資料或有變動
         if is_new_or_changed {
-            // 呼叫下方的 update_stock_info 進行實質的資料庫寫入與通知動作
-            if let Err(why) = update_stock_info(&item, &mut to_bot_msg).await {
-                // 若更新單一項目失敗，記錄錯誤日誌，但不中斷整個批次流程
+            let cmd = EtfAclMapper::to_registration_command(&item);
+            if let Err(why) = update_stock_info(&cmd).await {
                 logging::error_file_async(format!(
                     "更新 ETF {} 資訊失敗: {:?}",
                     item.stock_symbol, why
@@ -73,77 +58,39 @@ async fn update_stocks(items: Vec<EtfInfo>) -> Result<()> {
         }
     }
 
-    // 如果累積的變動訊息不為空，代表有新增或更新，則發送一次 Telegram 通知
-    if !to_bot_msg.is_empty() {
-        bot::telegram::send(&to_bot_msg).await;
-    }
-
     Ok(())
 }
 
-async fn update_stock_info(etf: &EtfInfo, msg: &mut String) -> Result<()> {
+async fn update_stock_info(cmd: &backfill::acl::RegisterStockCommand) -> Result<()> {
+    use crate::app::event::handlers::get_global_dispatcher;
     use crate::domain::registry::entity::Stock;
     use crate::domain::registry::repository::StockRepository;
     use crate::infra::database::repository::stock::PgStockRepository;
-    use crate::interfaces::rpc::stock::StockInfoRequest;
 
     let repo = PgStockRepository::new();
 
     // 1. 獲取已存在的證券主檔或註冊一個新的，並使用業務方法更新識別資訊
-    let stock = match repo.find_by_symbol(&etf.stock_symbol).await? {
+    let mut stock = match repo.find_by_symbol(&cmd.symbol).await? {
         Some(mut existing) => {
-            existing.change_identity(
-                etf.name.clone(),
-                etf.exchange_market.stock_exchange_market_id,
-                etf.industry_id,
-            );
+            existing.change_identity(cmd.name.clone(), cmd.market_id, cmd.industry_id);
             existing
         }
         None => Stock::register(
-            etf.stock_symbol.clone(),
-            etf.name.clone(),
-            etf.exchange_market.stock_exchange_market_id,
-            etf.industry_id,
+            cmd.symbol.clone(),
+            cmd.name.clone(),
+            cmd.market_id,
+            cmd.industry_id,
         ),
     };
 
-    // 2. 寫入資料庫：利用 Repository 保存，會自動觸發搜尋索引重建與快取同步
+    // 2. 寫入資料庫：利用 Repository 保存，會自動觸發快取同步
     repo.save(&stock)
         .await
-        .map_err(|why| anyhow!("資料庫 upsert 失敗: {:?}", why))?;
+        .map_err(|why| anyhow::anyhow!("資料庫 upsert 失敗: {:?}", why))?;
 
-    // 3. 取得易讀的名稱（用於日誌與通知）
-    let market = StockExchangeMarket::from(stock.market_id());
-    let market_name = market
-        .map(|m| m.name())
-        .unwrap_or_else(|| "未知".to_string());
-    let industry_name = SHARE
-        .get_industry_name(stock.industry_id())
-        .unwrap_or_else(|| "未知".to_string());
-
-    // 組合要顯示在通知與日誌上的訊息文字
-    let log_msg = format!(
-        "新增/更新 ETF︰ {} {} {} {}",
-        stock.symbol().0,
-        Telegram::escape_markdown_v2(stock.name()), // 處理 Telegram 特殊符號轉義
-        market_name,
-        industry_name
-    );
-
-    // 將訊息附加到傳入的訊息緩衝區
-    writeln!(msg, "{}\r\n", log_msg).ok();
-    // 同步記錄到系統檔案日誌
-    logging::info_file_async(&log_msg);
-
-    // 4. 跨服務通知：透過 gRPC 將最新的股票基本資料推送到其他微服務 (Go Service)
-    let request = StockInfoRequest::from(&stock);
-    if let Err(why) = rpc::client::stock_service::push_stock_info_to_go_service(request).await {
-        logging::error_file_async(format!(
-            "推送 ETF 資訊至 Go Service 失敗 ({}): {:?}",
-            stock.symbol().0,
-            why
-        ));
-    }
+    // 3. 提取領域事件並非同步派發
+    let events = stock.pull_events();
+    get_global_dispatcher().dispatch_async(events).await;
 
     Ok(())
 }
@@ -152,6 +99,7 @@ async fn update_stock_info(etf: &EtfInfo, msg: &mut String) -> Result<()> {
 mod tests {
     use super::*;
     use crate::core::logging;
+    use crate::infra::cache::SHARE;
 
     #[tokio::test]
     #[ignore]

--- a/src/app/backfill/qualified_foreign_institutional_investor.rs
+++ b/src/app/backfill/qualified_foreign_institutional_investor.rs
@@ -1,7 +1,10 @@
 use crate::{
-    core::logging, core::util::datetime::Weekend, domain::registry::repository::StockRepository,
-    infra::crawler::twse, infra::database::repository::stock::PgStockRepository,
-    infra::database::table::stock::extension::qualified_foreign_institutional_investor::QualifiedForeignInstitutionalInvestor,
+    app::backfill::acl::{QfiiAclMapper, UpdateQfiiCommand},
+    core::logging,
+    core::util::datetime::Weekend,
+    domain::registry::repository::StockRepository,
+    infra::crawler::twse,
+    infra::database::repository::stock::PgStockRepository,
 };
 use anyhow::Result;
 use chrono::{DateTime, FixedOffset, Local};
@@ -26,39 +29,44 @@ pub async fn execute() -> Result<()> {
 
 async fn listed(date_time: DateTime<FixedOffset>) -> Result<()> {
     let listed = twse::qualified_foreign_institutional_investor::listed::visit(date_time).await?;
-    update(listed).await
+    let cmds = listed
+        .iter()
+        .map(QfiiAclMapper::to_update_command)
+        .collect();
+    update(cmds).await
 }
 
 /// 回補上櫃外資持股資料。
 async fn otc() -> Result<()> {
     let toc = twse::qualified_foreign_institutional_investor::over_the_counter::visit().await?;
-    update(toc).await
+    let cmds = toc.iter().map(QfiiAclMapper::to_update_command).collect();
+    update(cmds).await
 }
 
 /// 更新股票的外資持股狀況，資料庫更新後會更新 SHARE.stocks
-async fn update(qfiis: Vec<QualifiedForeignInstitutionalInvestor>) -> Result<()> {
+async fn update(cmds: Vec<UpdateQfiiCommand>) -> Result<()> {
     let repo = PgStockRepository::new();
 
-    for qfii in qfiis {
+    for cmd in cmds {
         // 嘗試讀取 Stock 聚合根
-        let stock_opt = repo.find_by_symbol(&qfii.stock_symbol).await?;
+        let stock_opt = repo.find_by_symbol(&cmd.symbol).await?;
         if let Some(mut stock) = stock_opt {
-            if stock.issued_share() == qfii.issued_share
-                && stock.qfii_shares_held() == qfii.qfii_shares_held
-                && stock.qfii_share_holding_percentage() == qfii.qfii_share_holding_percentage
+            if stock.issued_share() == cmd.issued_share
+                && stock.qfii_shares_held() == cmd.shares_held
+                && stock.qfii_share_holding_percentage() == cmd.share_holding_percentage
             {
                 continue;
             }
 
             // 使用領域模型更新狀態
-            stock.update_qfii(qfii.qfii_shares_held, qfii.qfii_share_holding_percentage);
-            stock.update_issued_shares(qfii.issued_share);
+            stock.update_qfii(cmd.shares_held, cmd.share_holding_percentage);
+            stock.update_issued_shares(cmd.issued_share);
 
             // 儲存 Stock 聚合根，同時更新 DB 與快取
             if let Err(why) = repo.save(&stock).await {
                 logging::error_file_async(format!(
                     "Failed to save stock QFII updates for {} because {:?}",
-                    qfii.stock_symbol, why
+                    cmd.symbol, why
                 ));
             }
         }


### PR DESCRIPTION
Expands the Anti-Corruption Layer (ACL) mapping to delisted companies, QFII updates, and ETF info backfill tasks. Decouples use cases from raw crawler DTOs and database table extension models.