### PR TITLE
refactor: ddd phase 7 - expand anti-corruption layer to daily quotes and monthly revenues

### DIFF
--- a/src/app/backfill/acl.rs
+++ b/src/app/backfill/acl.rs
@@ -2,10 +2,11 @@
 //!
 //! 用於隔離外部爬蟲資料結構（Crawler DTO）與應用層/領域層之業務邏輯命令或實體。
 
-use crate::infra::crawler::share::EtfInfo;
+use crate::infra::crawler::share::{DailyQuoteDto, EtfInfo, RevenueDto};
 use crate::infra::crawler::twse::international_securities_identification_number::InternationalSecuritiesIdentificationNumber;
 use crate::infra::crawler::twse::suspend_listing::SuspendListing;
 use crate::infra::database::table::stock::extension::qualified_foreign_institutional_investor::QualifiedForeignInstitutionalInvestor;
+use chrono::{Datelike, NaiveDate};
 use rust_decimal::Decimal;
 
 /// 註冊或變更證券識別資料命令。
@@ -39,6 +40,70 @@ pub struct UpdateQfiiCommand {
     pub share_holding_percentage: Decimal,
     /// 已發行股數
     pub issued_share: i64,
+}
+
+/// 更新單月營收命令。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateRevenueCommand {
+    /// 股票代號
+    pub symbol: String,
+    /// 當月營收
+    pub monthly: Decimal,
+    /// 上月營收
+    pub last_month: Decimal,
+    /// 去年當月營收
+    pub last_year_this_month: Decimal,
+    /// 當月累計營收
+    pub monthly_accumulated: Decimal,
+    /// 去年累計營收
+    pub last_year_monthly_accumulated: Decimal,
+    /// 上月比較增減(%)
+    pub compared_with_last_month: Decimal,
+    /// 去年同月增減(%)
+    pub compared_with_last_year_same_month: Decimal,
+    /// 前期比較增減(%)
+    pub accumulated_compared_with_last_year: Decimal,
+    /// 營收月份 (YYYYMM 格式整數)
+    pub date: i64,
+}
+
+/// 儲存每日收盤報價命令。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SaveDailyQuoteCommand {
+    /// 股票代號
+    pub symbol: String,
+    /// 交易日期
+    pub date: NaiveDate,
+    /// 開盤價
+    pub opening_price: Decimal,
+    /// 最高價
+    pub highest_price: Decimal,
+    /// 最低價
+    pub lowest_price: Decimal,
+    /// 收盤價
+    pub closing_price: Decimal,
+    /// 漲跌價差
+    pub change: Decimal,
+    /// 漲跌幅（百分比）
+    pub change_range: Decimal,
+    /// 成交股數
+    pub trading_volume: Decimal,
+    /// 成交金額
+    pub trade_value: Decimal,
+    /// 成交筆數
+    pub transaction: Decimal,
+    /// 本益比
+    pub price_earning_ratio: Decimal,
+    /// 股價淨值比
+    pub price_to_book_ratio: Decimal,
+    /// 最後揭示買價
+    pub last_best_bid_price: Decimal,
+    /// 最後揭示買量
+    pub last_best_bid_volume: Decimal,
+    /// 最後揭示賣價
+    pub last_best_ask_price: Decimal,
+    /// 最後揭示賣量
+    pub last_best_ask_volume: Decimal,
 }
 
 /// ISIN 爬蟲資料防腐層轉譯器。
@@ -120,6 +185,117 @@ impl EtfAclMapper {
             market_id: dto.exchange_market.stock_exchange_market_id,
             industry_id: dto.industry_id,
         }
+    }
+}
+
+/// 營收爬蟲資料防腐層轉譯器。
+pub struct RevenueAclMapper;
+
+impl RevenueAclMapper {
+    /// 將原始爬蟲 DTO 轉譯成 `UpdateRevenueCommand`。
+    pub fn to_update_command(dto: &RevenueDto) -> UpdateRevenueCommand {
+        UpdateRevenueCommand {
+            symbol: dto.stock_symbol.clone(),
+            monthly: dto.monthly,
+            last_month: dto.last_month,
+            last_year_this_month: dto.last_year_this_month,
+            monthly_accumulated: dto.monthly_accumulated,
+            last_year_monthly_accumulated: dto.last_year_monthly_accumulated,
+            compared_with_last_month: dto.compared_with_last_month,
+            compared_with_last_year_same_month: dto.compared_with_last_year_same_month,
+            accumulated_compared_with_last_year: dto.accumulated_compared_with_last_year,
+            date: dto.date,
+        }
+    }
+
+    /// 將 `UpdateRevenueCommand` 轉譯為資料庫 Table 模型 `Revenue`。
+    pub fn to_database_entity(
+        cmd: &UpdateRevenueCommand,
+    ) -> crate::infra::database::table::financial::revenue::Revenue {
+        use chrono::Local;
+        let mut r = crate::infra::database::table::financial::revenue::Revenue::new();
+        r.stock_symbol = cmd.symbol.clone();
+        r.monthly = cmd.monthly;
+        r.last_month = cmd.last_month;
+        r.last_year_this_month = cmd.last_year_this_month;
+        r.monthly_accumulated = cmd.monthly_accumulated;
+        r.last_year_monthly_accumulated = cmd.last_year_monthly_accumulated;
+        r.compared_with_last_month = cmd.compared_with_last_month;
+        r.compared_with_last_year_same_month = cmd.compared_with_last_year_same_month;
+        r.accumulated_compared_with_last_year = cmd.accumulated_compared_with_last_year;
+        r.date = cmd.date;
+        r.create_time = Local::now();
+        r
+    }
+}
+
+/// 每日收盤報價爬蟲資料防腐層轉譯器。
+pub struct QuoteAclMapper;
+
+impl QuoteAclMapper {
+    /// 將爬蟲 DTO 轉譯成系統內部的 `SaveDailyQuoteCommand`。
+    pub fn to_save_command(dto: &DailyQuoteDto) -> SaveDailyQuoteCommand {
+        SaveDailyQuoteCommand {
+            symbol: dto.symbol.clone(),
+            date: dto.date,
+            opening_price: dto.opening_price,
+            highest_price: dto.highest_price,
+            lowest_price: dto.lowest_price,
+            closing_price: dto.closing_price,
+            change: dto.change,
+            change_range: dto.change_range,
+            trading_volume: dto.trading_volume,
+            trade_value: dto.trade_value,
+            transaction: dto.transaction,
+            price_earning_ratio: dto.price_earning_ratio,
+            price_to_book_ratio: dto.price_to_book_ratio,
+            last_best_bid_price: dto.last_best_bid_price,
+            last_best_bid_volume: dto.last_best_bid_volume,
+            last_best_ask_price: dto.last_best_ask_price,
+            last_best_ask_volume: dto.last_best_ask_volume,
+        }
+    }
+
+    /// 將 `SaveDailyQuoteCommand` 轉譯為資料庫 Table 模型 `DailyQuote`。
+    pub fn to_database_entity(
+        cmd: &SaveDailyQuoteCommand,
+    ) -> crate::infra::database::table::daily_quote::DailyQuote {
+        use chrono::{Local, TimeZone};
+        let mut dq =
+            crate::infra::database::table::daily_quote::DailyQuote::new(cmd.symbol.clone());
+
+        dq.date = cmd.date;
+        dq.year = cmd.date.year();
+        dq.month = cmd.date.month() as i32;
+        dq.day = cmd.date.day() as i32;
+        dq.opening_price = cmd.opening_price;
+        dq.highest_price = cmd.highest_price;
+        dq.lowest_price = cmd.lowest_price;
+        dq.closing_price = cmd.closing_price;
+        dq.change = cmd.change;
+        dq.change_range = cmd.change_range;
+        dq.trading_volume = cmd.trading_volume;
+        dq.trade_value = cmd.trade_value;
+        dq.transaction = cmd.transaction;
+        dq.price_earning_ratio = cmd.price_earning_ratio;
+        dq.price_to_book_ratio = cmd.price_to_book_ratio;
+        dq.last_best_bid_price = cmd.last_best_bid_price;
+        dq.last_best_bid_volume = cmd.last_best_bid_volume;
+        dq.last_best_ask_price = cmd.last_best_ask_price;
+        dq.last_best_ask_volume = cmd.last_best_ask_volume;
+
+        // 台北時區 (UTC+8)
+        let timezone = chrono::FixedOffset::east_opt(8 * 3600).unwrap();
+        let record_time = cmd
+            .date
+            .and_hms_opt(15, 0, 0)
+            .and_then(|naive| timezone.from_local_datetime(&naive).single())
+            .unwrap_or_else(|| Local::now().with_timezone(&timezone));
+
+        dq.record_time = record_time.with_timezone(&Local);
+        dq.create_time = Local::now();
+
+        dq
     }
 }
 
@@ -237,5 +413,63 @@ mod tests {
         assert_eq!(cmd.name, "元大台灣50");
         assert_eq!(cmd.market_id, 2);
         assert_eq!(cmd.industry_id, 9001);
+    }
+
+    #[test]
+    fn test_revenue_acl_mapping() {
+        let dto = RevenueDto {
+            stock_symbol: "2330".to_string(),
+            monthly: dec!(1000.0),
+            last_month: dec!(900.0),
+            last_year_this_month: dec!(950.0),
+            monthly_accumulated: dec!(5000.0),
+            last_year_monthly_accumulated: dec!(4500.0),
+            compared_with_last_month: dec!(11.1),
+            compared_with_last_year_same_month: dec!(5.3),
+            accumulated_compared_with_last_year: dec!(11.1),
+            date: 202605,
+        };
+
+        let cmd = RevenueAclMapper::to_update_command(&dto);
+        assert_eq!(cmd.symbol, "2330");
+        assert_eq!(cmd.monthly, dec!(1000.0));
+        assert_eq!(cmd.date, 202605);
+
+        let entity = RevenueAclMapper::to_database_entity(&cmd);
+        assert_eq!(entity.stock_symbol, "2330");
+        assert_eq!(entity.monthly, dec!(1000.0));
+        assert_eq!(entity.date, 202605);
+    }
+
+    #[test]
+    fn test_quote_acl_mapping() {
+        let dto = DailyQuoteDto {
+            symbol: "2330".to_string(),
+            date: NaiveDate::from_ymd_opt(2026, 6, 5).unwrap(),
+            opening_price: dec!(900.0),
+            highest_price: dec!(910.0),
+            lowest_price: dec!(895.0),
+            closing_price: dec!(905.0),
+            change: dec!(5.0),
+            change_range: dec!(0.55),
+            trading_volume: dec!(10000),
+            trade_value: dec!(9000000),
+            transaction: dec!(500),
+            price_earning_ratio: dec!(20.5),
+            price_to_book_ratio: dec!(5.2),
+            last_best_bid_price: dec!(904.0),
+            last_best_bid_volume: dec!(10),
+            last_best_ask_price: dec!(905.0),
+            last_best_ask_volume: dec!(20),
+        };
+
+        let cmd = QuoteAclMapper::to_save_command(&dto);
+        assert_eq!(cmd.symbol, "2330");
+        assert_eq!(cmd.closing_price, dec!(905.0));
+
+        let entity = QuoteAclMapper::to_database_entity(&cmd);
+        assert_eq!(entity.stock_symbol, "2330");
+        assert_eq!(entity.closing_price, dec!(905.0));
+        assert_eq!(entity.date, NaiveDate::from_ymd_opt(2026, 6, 5).unwrap());
     }
 }

--- a/src/app/backfill/quote.rs
+++ b/src/app/backfill/quote.rs
@@ -5,12 +5,12 @@ use chrono::NaiveDate;
 use futures::{stream, StreamExt};
 
 use crate::{
+    app::backfill::acl::QuoteAclMapper,
     core::logging,
-    core::util,
-    core::util::map::Keyable,
+    core::util::{self, map::Keyable},
     infra::cache::{TtlCacheInner, SHARE, TTL},
-    infra::crawler::{tpex, twse},
-    infra::database::table::{self, daily_quote::DailyQuote},
+    infra::crawler::{share::DailyQuoteDto, tpex, twse},
+    infra::database::table,
 };
 
 /// 調用  twse、tpex API 取得台股收盤報價
@@ -19,8 +19,8 @@ pub async fn execute(date: NaiveDate) -> Result<usize> {
     let twse = twse::quote::visit(date);
     //上櫃報價
     let tpex = tpex::quote::visit(date);
-    let mut quotes_twse: Vec<DailyQuote> = Vec::with_capacity(1024);
-    let mut quotes_tpex: Vec<DailyQuote> = Vec::with_capacity(1024);
+    let mut quotes_twse: Vec<DailyQuoteDto> = Vec::with_capacity(1024);
+    let mut quotes_tpex: Vec<DailyQuoteDto> = Vec::with_capacity(1024);
     let get_twse = get_quotes_from_source(twse, "上市", &mut quotes_twse);
     let get_tpex = get_quotes_from_source(tpex, "上櫃", &mut quotes_tpex);
     let (result_twse, result_tpex) = tokio::join!(get_twse, get_tpex);
@@ -50,9 +50,9 @@ pub async fn execute(date: NaiveDate) -> Result<usize> {
 
 /// 從指定資料來源抓取收盤價並附加到輸出向量。
 pub async fn get_quotes_from_source(
-    source: impl Future<Output = Result<Vec<DailyQuote>>>,
+    source: impl Future<Output = Result<Vec<DailyQuoteDto>>>,
     source_name: &str,
-    quotes: &mut Vec<DailyQuote>,
+    quotes: &mut Vec<DailyQuoteDto>,
 ) -> Result<()> {
     if let Ok(quote) = source.await {
         quotes.extend(quote);
@@ -62,9 +62,17 @@ pub async fn get_quotes_from_source(
 }
 
 /// 將收盤價整批寫入資料庫並更新主快取。
-pub async fn process_quotes(quotes: Vec<DailyQuote>) {
-    let result_count = DailyQuote::copy_in_raw(&quotes).await.unwrap_or_default();
-    stream::iter(quotes)
+pub async fn process_quotes(quotes: Vec<DailyQuoteDto>) {
+    let cmds: Vec<_> = quotes.iter().map(QuoteAclMapper::to_save_command).collect();
+    let entities: Vec<_> = cmds
+        .iter()
+        .map(QuoteAclMapper::to_database_entity)
+        .collect();
+
+    let result_count = table::daily_quote::DailyQuote::copy_in_raw(&entities)
+        .await
+        .unwrap_or_default();
+    stream::iter(entities)
         .for_each_concurrent(util::concurrent_limit_32(), |dq| async move {
             process_daily_quote(dq).await;
         })
@@ -72,7 +80,7 @@ pub async fn process_quotes(quotes: Vec<DailyQuote>) {
     logging::info_file_async(format!("上市櫃收盤數據更新到資料庫完成: {}", result_count));
 }
 
-async fn process_daily_quote(daily_quote: DailyQuote) {
+async fn process_daily_quote(daily_quote: table::daily_quote::DailyQuote) {
     SHARE.set_stock_last_price(&daily_quote).await;
 
     let daily_quote_memory_key = daily_quote.key_with_prefix();

--- a/src/app/backfill/revenue.rs
+++ b/src/app/backfill/revenue.rs
@@ -1,4 +1,5 @@
 use crate::{
+    app::backfill::acl::{RevenueAclMapper, UpdateRevenueCommand},
     core::logging,
     core::util,
     infra::cache::SHARE,
@@ -34,9 +35,14 @@ async fn process_revenues(last_month_timezone: chrono::DateTime<FixedOffset>) ->
     let month = last_month_timezone.month();
 
     let revenues = twse::revenue::visit(last_month_timezone).await?;
-    stream::iter(revenues)
-        .for_each_concurrent(util::concurrent_limit_16(), |r| async move {
-            if let Err(why) = process_revenue(r, year, month as i32).await {
+    let cmds: Vec<UpdateRevenueCommand> = revenues
+        .iter()
+        .map(RevenueAclMapper::to_update_command)
+        .collect();
+
+    stream::iter(cmds)
+        .for_each_concurrent(util::concurrent_limit_16(), |cmd| async move {
+            if let Err(why) = process_revenue(cmd, year, month as i32).await {
                 logging::error_file_async(format!("Failed to process_revenue because {:?}", why));
             }
         })
@@ -48,24 +54,25 @@ async fn process_revenues(last_month_timezone: chrono::DateTime<FixedOffset>) ->
 }
 
 pub(crate) async fn process_revenue(
-    mut revenue: revenue::Revenue,
+    cmd: UpdateRevenueCommand,
     year: i32,
     month: i32,
 ) -> Result<()> {
+    let mut revenue_entity = RevenueAclMapper::to_database_entity(&cmd);
+
     if let Ok(dq) =
-        table::daily_quote::fetch_monthly_stock_price_summary(&revenue.stock_symbol, year, month)
-            .await
+        table::daily_quote::fetch_monthly_stock_price_summary(&cmd.symbol, year, month).await
     {
-        revenue.lowest_price = dq.lowest_price;
-        revenue.avg_price = dq.avg_price;
-        revenue.highest_price = dq.highest_price;
+        revenue_entity.lowest_price = dq.lowest_price;
+        revenue_entity.avg_price = dq.avg_price;
+        revenue_entity.highest_price = dq.highest_price;
     }
 
-    revenue.upsert().await?;
+    revenue_entity.upsert().await?;
 
-    SHARE.set_last_revenues(revenue.clone());
+    SHARE.set_last_revenues(revenue_entity.clone());
 
-    let name = match SHARE.get_stock(&revenue.stock_symbol).await {
+    let name = match SHARE.get_stock(&cmd.symbol).await {
         None => String::from("-"),
         Some(s) => s.name().to_string(),
     };
@@ -73,14 +80,14 @@ pub(crate) async fn process_revenue(
     logging::info_file_async(
         format!(
             "公司代號:{}  公司名稱:{} 當月營收:{} 上月營收:{} 去年當月營收:{} 月均價:{} 最低價:{} 最高價:{}",
-            revenue.stock_symbol,
+            cmd.symbol,
             name,
-            revenue.monthly,
-            revenue.last_month,
-            revenue.last_year_this_month,
-            revenue.avg_price,
-            revenue.lowest_price,
-            revenue.highest_price));
+            cmd.monthly,
+            cmd.last_month,
+            cmd.last_year_this_month,
+            revenue_entity.avg_price,
+            revenue_entity.lowest_price,
+            revenue_entity.highest_price));
 
     Ok(())
 }

--- a/src/infra/crawler/share.rs
+++ b/src/infra/crawler/share.rs
@@ -5,9 +5,11 @@ use std::{
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+use chrono::NaiveDate;
 use rust_decimal::Decimal;
 use scraper::{ElementRef, Html, Selector};
 
+use crate::core::declare::StockExchange;
 use crate::infra::crawler::{bigdatacloud, myip};
 use crate::{
     core::util::{self, map::Keyable, text},
@@ -213,6 +215,331 @@ fn normalize_public_ip(service_name: &str, ip: &str) -> Result<String> {
         .parse::<IpAddr>()
         .map(|ip| ip.to_string())
         .map_err(|why| anyhow!("{service_name}: invalid ip response `{normalized}` because {why}"))
+}
+
+/// 營收資訊爬蟲載體 (DTO)。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RevenueDto {
+    /// 股票代號
+    pub stock_symbol: String,
+    /// 當月營收
+    pub monthly: Decimal,
+    /// 上月營收
+    pub last_month: Decimal,
+    /// 去年當月營收
+    pub last_year_this_month: Decimal,
+    /// 當月累計營收
+    pub monthly_accumulated: Decimal,
+    /// 去年累計營收
+    pub last_year_monthly_accumulated: Decimal,
+    /// 上月比較增減(%)
+    pub compared_with_last_month: Decimal,
+    /// 去年同月增減(%)
+    pub compared_with_last_year_same_month: Decimal,
+    /// 前期比較增減(%)
+    pub accumulated_compared_with_last_year: Decimal,
+    /// 營收月份 (YYYYMM 格式整數，如 202605)
+    pub date: i64,
+}
+
+impl From<Vec<String>> for RevenueDto {
+    fn from(item: Vec<String>) -> Self {
+        use std::str::FromStr;
+        let stock_symbol = item[0].to_string();
+
+        let monthly = {
+            let s = item[2].replace([',', ' '], "");
+            if s.is_empty() {
+                Default::default()
+            } else {
+                Decimal::from_str(&s).unwrap_or_else(|err| {
+                    eprintln!("Failed to parse 'monthly'({}) field: {}", item[2], err);
+                    Default::default()
+                })
+            }
+        };
+        let last_month = {
+            let s = item[3].replace([',', ' '], "");
+            if s.is_empty() {
+                Default::default()
+            } else {
+                Decimal::from_str(&s).unwrap_or_else(|err| {
+                    eprintln!("Failed to parse 'last_month'({}) field: {}", item[3], err);
+                    Default::default()
+                })
+            }
+        };
+        let last_year_this_month = {
+            let s = item[4].replace([',', ' '], "");
+            if s.is_empty() {
+                Default::default()
+            } else {
+                Decimal::from_str(&s).unwrap_or_else(|err| {
+                    eprintln!(
+                        "Failed to parse 'last_year_this_month'({}) field: {}",
+                        item[4], err
+                    );
+                    Default::default()
+                })
+            }
+        };
+        let monthly_accumulated = {
+            let s = item[7].replace([',', ' '], "");
+            if s.is_empty() {
+                Default::default()
+            } else {
+                Decimal::from_str(&s).unwrap_or_else(|err| {
+                    eprintln!(
+                        "Failed to parse 'monthly_accumulated'({}) field: {}",
+                        item[7], err
+                    );
+                    Default::default()
+                })
+            }
+        };
+        let last_year_monthly_accumulated = {
+            let s = item[8].replace([',', ' '], "");
+            if s.is_empty() {
+                Default::default()
+            } else {
+                Decimal::from_str(&s).unwrap_or_else(|err| {
+                    eprintln!(
+                        "Failed to parse 'last_year_monthly_accumulated'({}) field: {}",
+                        item[8], err
+                    );
+                    Default::default()
+                })
+            }
+        };
+        let compared_with_last_month = {
+            let s = item[5].replace([',', ' '], "");
+            if s.is_empty() {
+                Default::default()
+            } else {
+                Decimal::from_str(&s).unwrap_or_else(|err| {
+                    eprintln!(
+                        "Failed to parse 'compared_with_last_month'({}) field: {}",
+                        item[5], err
+                    );
+                    Default::default()
+                })
+            }
+        };
+        let compared_with_last_year_same_month = {
+            let s = item[6].replace([',', ' '], "");
+            if s.is_empty() {
+                Default::default()
+            } else {
+                Decimal::from_str(&s).unwrap_or_else(|err| {
+                    eprintln!(
+                        "Failed to parse 'compared_with_last_year_same_month'({}) field: {}",
+                        item[6], err
+                    );
+                    Default::default()
+                })
+            }
+        };
+        let accumulated_compared_with_last_year = {
+            let s = item[9].replace([',', ' '], "");
+            if s.is_empty() {
+                Default::default()
+            } else {
+                Decimal::from_str(&s).unwrap_or_else(|err| {
+                    eprintln!(
+                        "Failed to parse 'accumulated_compared_with_last_year'({}) field: {}",
+                        item[9], err
+                    );
+                    Default::default()
+                })
+            }
+        };
+
+        Self {
+            stock_symbol,
+            monthly,
+            last_month,
+            last_year_this_month,
+            monthly_accumulated,
+            last_year_monthly_accumulated,
+            compared_with_last_month,
+            compared_with_last_year_same_month,
+            accumulated_compared_with_last_year,
+            date: 0,
+        }
+    }
+}
+
+/// 每日收盤報價爬蟲載體 (DTO)。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DailyQuoteDto {
+    /// 股票代號
+    pub symbol: String,
+    /// 交易日期
+    pub date: NaiveDate,
+    /// 開盤價
+    pub opening_price: Decimal,
+    /// 最高價
+    pub highest_price: Decimal,
+    /// 最低價
+    pub lowest_price: Decimal,
+    /// 收盤價
+    pub closing_price: Decimal,
+    /// 漲跌價差
+    pub change: Decimal,
+    /// 漲跌幅（百分比）
+    pub change_range: Decimal,
+    /// 成交股數
+    pub trading_volume: Decimal,
+    /// 成交金額
+    pub trade_value: Decimal,
+    /// 成交筆數
+    pub transaction: Decimal,
+    /// 本益比
+    pub price_earning_ratio: Decimal,
+    /// 股價淨值比
+    pub price_to_book_ratio: Decimal,
+    /// 最後揭示買價
+    pub last_best_bid_price: Decimal,
+    /// 最後揭示買量
+    pub last_best_bid_volume: Decimal,
+    /// 最後揭示賣價
+    pub last_best_ask_price: Decimal,
+    /// 最後揭示賣量
+    pub last_best_ask_volume: Decimal,
+}
+
+impl DailyQuoteDto {
+    /// 建立 `DailyQuoteDto` 預設實例，並同步初始化代碼與日期。
+    pub fn new<S: Into<String>>(symbol: S, date: NaiveDate) -> Self {
+        Self {
+            symbol: symbol.into(),
+            date,
+            opening_price: Decimal::ZERO,
+            highest_price: Decimal::ZERO,
+            lowest_price: Decimal::ZERO,
+            closing_price: Decimal::ZERO,
+            change: Decimal::ZERO,
+            change_range: Decimal::ZERO,
+            trading_volume: Decimal::ZERO,
+            trade_value: Decimal::ZERO,
+            transaction: Decimal::ZERO,
+            price_earning_ratio: Decimal::ZERO,
+            price_to_book_ratio: Decimal::ZERO,
+            last_best_bid_price: Decimal::ZERO,
+            last_best_bid_volume: Decimal::ZERO,
+            last_best_ask_price: Decimal::ZERO,
+            last_best_ask_volume: Decimal::ZERO,
+        }
+    }
+
+    /// 依欄位名稱映射，從單筆原始字串資料建立 `DailyQuoteDto`。
+    pub fn from_with_map(
+        item: &[String],
+        map: &std::collections::HashMap<&str, usize>,
+        date: NaiveDate,
+    ) -> Self {
+        let code = map
+            .get("證券代號")
+            .and_then(|&i| item.get(i))
+            .cloned()
+            .unwrap_or_default();
+        let mut dto = DailyQuoteDto::new(code, date);
+
+        let parse_decimal = |key: &str| -> Decimal {
+            map.get(key)
+                .and_then(|&i| item.get(i))
+                .map(|s| s.replace(',', ""))
+                .and_then(|s| s.parse::<Decimal>().ok())
+                .unwrap_or_default()
+        };
+
+        dto.trading_volume = parse_decimal("成交股數");
+        dto.transaction = parse_decimal("成交筆數");
+        dto.trade_value = parse_decimal("成交金額");
+        dto.opening_price = parse_decimal("開盤價");
+        dto.highest_price = parse_decimal("最高價");
+        dto.lowest_price = parse_decimal("最低價");
+        dto.closing_price = parse_decimal("收盤價");
+        dto.change = parse_decimal("漲跌價差");
+        dto.last_best_bid_price = parse_decimal("最後揭示買價");
+        dto.last_best_bid_volume = parse_decimal("最後揭示買量");
+        dto.last_best_ask_price = parse_decimal("最後揭示賣價");
+        dto.last_best_ask_volume = parse_decimal("最後揭示賣量");
+        dto.price_earning_ratio = parse_decimal("本益比");
+
+        // 處理漲跌符號
+        if let Some(&i) = map.get("漲跌(+/-)") {
+            if let Some(sign) = item.get(i) {
+                if sign.contains('-') || sign.contains('綠') {
+                    dto.change = -dto.change.abs();
+                } else if sign.contains('+') || sign.contains('紅') {
+                    dto.change = dto.change.abs();
+                }
+            }
+        }
+
+        dto
+    }
+
+    /// 在給定交易所與日期的前提下，將來源資料轉成 `DailyQuoteDto`。
+    pub fn from_with_exchange(exchange: StockExchange, item: &[String], date: NaiveDate) -> Self {
+        let mut dto = DailyQuoteDto::new(item[0].to_string(), date);
+
+        match exchange {
+            StockExchange::TWSE => {
+                let decimal_fields = [
+                    (2, &mut dto.trading_volume),
+                    (3, &mut dto.transaction),
+                    (4, &mut dto.trade_value),
+                    (5, &mut dto.opening_price),
+                    (6, &mut dto.highest_price),
+                    (7, &mut dto.lowest_price),
+                    (8, &mut dto.closing_price),
+                    (10, &mut dto.change),
+                    (11, &mut dto.last_best_bid_price),
+                    (12, &mut dto.last_best_bid_volume),
+                    (13, &mut dto.last_best_ask_price),
+                    (14, &mut dto.last_best_ask_volume),
+                    (15, &mut dto.price_earning_ratio),
+                ];
+
+                for (index, field) in decimal_fields {
+                    let d = item.get(index).unwrap_or(&"".to_string()).replace(',', "");
+                    *field = d.parse::<Decimal>().unwrap_or_default();
+                }
+
+                if let Some(change_str) = item.get(9) {
+                    if change_str.contains('-') {
+                        dto.change = -dto.change;
+                    }
+                }
+            }
+            StockExchange::TPEx => {
+                let decimal_fields = [
+                    (7, &mut dto.trading_volume),
+                    (9, &mut dto.transaction),
+                    (8, &mut dto.trade_value),
+                    (4, &mut dto.opening_price),
+                    (5, &mut dto.highest_price),
+                    (6, &mut dto.lowest_price),
+                    (2, &mut dto.closing_price),
+                    (3, &mut dto.change),
+                    (10, &mut dto.last_best_bid_price),
+                    (11, &mut dto.last_best_bid_volume),
+                    (12, &mut dto.last_best_ask_price),
+                    (13, &mut dto.last_best_ask_volume),
+                ];
+
+                for (index, field) in decimal_fields {
+                    let d = item.get(index).unwrap_or(&"".to_string()).replace(',', "");
+                    *field = d.parse::<Decimal>().unwrap_or_default();
+                }
+            }
+            _ => {}
+        }
+
+        dto
+    }
 }
 
 #[cfg(test)]

--- a/src/infra/crawler/tpex/quote.rs
+++ b/src/infra/crawler/tpex/quote.rs
@@ -1,13 +1,11 @@
 use crate::{
     core::declare::StockExchange,
-    core::logging,
-    core::util::{self, map::Keyable},
+    core::util,
     infra::cache::{TtlCacheInner, TTL},
-    infra::crawler::tpex,
-    infra::database::table::{self, daily_quote::FromWithExchange},
+    infra::crawler::{share::DailyQuoteDto, tpex},
 };
 use anyhow::Result;
-use chrono::{Datelike, Local, NaiveDate, TimeZone};
+use chrono::{Datelike, NaiveDate};
 use hashbrown::HashMap;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -54,7 +52,7 @@ struct PeRatioAnalysisResponse {
 }
 
 /// 抓取上櫃公司每日收盤資訊
-pub async fn visit(date: NaiveDate) -> Result<Vec<table::daily_quote::DailyQuote>> {
+pub async fn visit(date: NaiveDate) -> Result<Vec<DailyQuoteDto>> {
     let pe_ratio_url = "https://www.tpex.org.tw/openapi/v1/tpex_mainboard_peratio_analysis";
     // 本益比
     let pe_ratio_response =
@@ -77,68 +75,50 @@ pub async fn visit(date: NaiveDate) -> Result<Vec<table::daily_quote::DailyQuote
     );
 
     let quote_response = util::http::get_json::<QuoteResponse>(&quote_url).await?;
-    let mut dqs: Vec<table::daily_quote::DailyQuote> = Vec::with_capacity(2048);
+    let mut dqs: Vec<DailyQuoteDto> = Vec::with_capacity(2048);
     if !quote_response.tables.is_empty() {
         if let Some(tpex_dqs) = &quote_response.tables[0].data {
             for item in tpex_dqs {
-                let mut dq =
-                    table::daily_quote::DailyQuote::from_with_exchange(StockExchange::TPEx, item);
-                //logging::debug_file_async(format!("item:{:?}", item));
+                let mut dto = DailyQuoteDto::from_with_exchange(StockExchange::TPEx, item, date);
 
-                if dq.closing_price.is_zero()
-                    && dq.highest_price.is_zero()
-                    && dq.lowest_price.is_zero()
-                    && dq.opening_price.is_zero()
+                if dto.closing_price.is_zero()
+                    && dto.highest_price.is_zero()
+                    && dto.lowest_price.is_zero()
+                    && dto.opening_price.is_zero()
                 {
                     continue;
                 }
 
-                let daily_quote_memory_key = dq.key();
+                let daily_quote_memory_key = format!("{}-{}", date.format("%Y%m%d"), dto.symbol);
 
                 if TTL.daily_quote_contains_key(&daily_quote_memory_key) {
                     continue;
                 }
 
-                if !dq.change.is_zero() {
+                if !dto.change.is_zero() {
                     if let Some(ldg) = crate::infra::cache::SHARE
-                        .get_last_trading_day_quotes(&dq.stock_symbol)
+                        .get_last_trading_day_quotes(&dto.symbol)
                         .await
                     {
                         if ldg.closing_price > Decimal::ZERO {
-                            // 漲幅 = (现价-上一个交易日收盘价）/ 上一个交易日收盘价*100%
-                            dq.change_range = (dq.closing_price - ldg.closing_price)
+                            // 漲幅 = (现价-上一個交易日收盤價）/ 上一個交易日收盤價*100%
+                            dto.change_range = (dto.closing_price - ldg.closing_price)
                                 / ldg.closing_price
                                 * dec!(100);
                         } else {
-                            dq.change_range = dq.change / dq.opening_price * dec!(100);
+                            dto.change_range = dto.change / dto.opening_price * dec!(100);
                         }
                     }
                 }
 
-                if let Some(pe_ratio_analysis_response) = pe_ratio_analysis.get(&dq.stock_symbol) {
-                    dq.price_earning_ratio = pe_ratio_analysis_response
+                if let Some(pe_ratio_analysis_response) = pe_ratio_analysis.get(&dto.symbol) {
+                    dto.price_earning_ratio = pe_ratio_analysis_response
                         .price_earning_ratio
                         .parse::<Decimal>()
                         .unwrap_or_default()
                 }
 
-                dq.date = date;
-                dq.year = date.year();
-                dq.month = date.month() as i32;
-                dq.day = date.day() as i32;
-
-                let record_time = date
-                    .and_hms_opt(15, 0, 0)
-                    .and_then(|naive| Local.from_local_datetime(&naive).single())
-                    .unwrap_or_else(|| {
-                        logging::warn_file_async("Failed to create DateTime<Local> from NaiveDateTime, using current time as default.".to_string());
-                        Local::now()
-                    });
-
-                dq.record_time = record_time;
-                dq.create_time = Local::now();
-
-                dqs.push(dq);
+                dqs.push(dto);
             }
         }
     }
@@ -148,7 +128,7 @@ pub async fn visit(date: NaiveDate) -> Result<Vec<table::daily_quote::DailyQuote
 
 #[cfg(test)]
 mod tests {
-    use chrono::{TimeDelta, Timelike};
+    use chrono::{Local, TimeDelta, Timelike};
     use std::time::Duration;
 
     use crate::{core::logging, infra::cache::SHARE};

--- a/src/infra/crawler/twse/quote.rs
+++ b/src/infra/crawler/twse/quote.rs
@@ -1,15 +1,14 @@
 use anyhow::Result;
-use chrono::{Datelike, Local, NaiveDate, TimeZone};
+use chrono::{Local, NaiveDate};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     core::logging,
-    core::util::{http, map::Keyable},
+    core::util::http,
     infra::cache::{TtlCacheInner, TTL},
-    infra::crawler::twse,
-    infra::database::table::{self},
+    infra::crawler::{share::DailyQuoteDto, twse},
 };
 
 /*#[derive(Serialize, Deserialize, Debug)]
@@ -79,7 +78,7 @@ fn is_twse_quote_table(table: &Table) -> bool {
 /// 3. 盡可能計算 `change_range` 後回傳當日清單。
 ///
 /// 若 API 可連線但找不到目標表格，會記錄 warning 並回傳空陣列。
-pub async fn visit(date: NaiveDate) -> Result<Vec<table::daily_quote::DailyQuote>> {
+pub async fn visit(date: NaiveDate) -> Result<Vec<DailyQuoteDto>> {
     let date_str = date.format("%Y%m%d").to_string();
     let now_ts = Local::now().timestamp_millis();
     let url = format!(
@@ -117,60 +116,40 @@ pub async fn visit(date: NaiveDate) -> Result<Vec<table::daily_quote::DailyQuote
 
         for item in rows {
             // 2. 使用動態映射解析資料
-            let mut dq = table::daily_quote::DailyQuote::from_with_map(item, &field_map);
+            let mut dto = DailyQuoteDto::from_with_map(item, &field_map, date);
 
-            if dq.closing_price.is_zero()
-                && dq.highest_price.is_zero()
-                && dq.lowest_price.is_zero()
-                && dq.opening_price.is_zero()
+            if dto.closing_price.is_zero()
+                && dto.highest_price.is_zero()
+                && dto.lowest_price.is_zero()
+                && dto.opening_price.is_zero()
             {
                 continue;
             }
 
-            let daily_quote_memory_key = dq.key();
+            let daily_quote_memory_key = format!("{}-{}", date.format("%Y%m%d"), dto.symbol);
 
             if TTL.daily_quote_contains_key(&daily_quote_memory_key) {
                 continue;
             }
 
-            if !dq.change.is_zero() {
+            if !dto.change.is_zero() {
                 if let Some(ldg) = crate::infra::cache::SHARE
-                    .get_last_trading_day_quotes(&dq.stock_symbol)
+                    .get_last_trading_day_quotes(&dto.symbol)
                     .await
                 {
                     if ldg.closing_price > Decimal::ZERO {
                         // 漲幅 = (现价-上一个交易日收盘价）/ 上一个交易日收盘价*100%
-                        dq.change_range =
-                            (dq.closing_price - ldg.closing_price) / ldg.closing_price * dec!(100);
-                    } else if dq.opening_price > Decimal::ZERO {
-                        dq.change_range = dq.change / dq.opening_price * dec!(100);
+                        dto.change_range =
+                            (dto.closing_price - ldg.closing_price) / ldg.closing_price * dec!(100);
+                    } else if dto.opening_price > Decimal::ZERO {
+                        dto.change_range = dto.change / dto.opening_price * dec!(100);
                     } else {
-                        dq.change_range = Decimal::ZERO;
+                        dto.change_range = Decimal::ZERO;
                     }
                 }
             }
 
-            dq.date = date;
-            dq.year = date.year();
-            dq.month = date.month() as i32;
-            dq.day = date.day() as i32;
-
-            // 台北時區 (UTC+8)
-            let timezone = chrono::FixedOffset::east_opt(8 * 3600).unwrap();
-            let record_time = date
-                .and_hms_opt(15, 0, 0)
-                .and_then(|naive| timezone.from_local_datetime(&naive).single())
-                .unwrap_or_else(|| {
-                    logging::warn_file_async(
-                        "Failed to create DateTime with Taipei timezone, using Local::now()."
-                            .to_string(),
-                    );
-                    Local::now().with_timezone(&timezone)
-                });
-
-            dq.record_time = record_time.with_timezone(&Local);
-            dq.create_time = Local::now();
-            dqs.push(dq);
+            dqs.push(dto);
         }
     } else {
         logging::warn_file_async(format!(

--- a/src/infra/crawler/twse/revenue.rs
+++ b/src/infra/crawler/twse/revenue.rs
@@ -3,11 +3,13 @@ use chrono::{Datelike, FixedOffset};
 use scraper::{Html, Selector};
 
 use crate::{
-    core::util, infra::cache::SHARE, infra::crawler::twse, infra::database::table::revenue,
+    core::util,
+    infra::cache::SHARE,
+    infra::crawler::{share::RevenueDto, twse},
 };
 
 /// 下載月營收
-pub async fn visit(date_time: chrono::DateTime<FixedOffset>) -> Result<Vec<revenue::Revenue>> {
+pub async fn visit(date_time: chrono::DateTime<FixedOffset>) -> Result<Vec<RevenueDto>> {
     let year = date_time.year();
     let republic_of_china_era = util::datetime::gregorian_year_to_roc_year(year);
     let month = date_time.month();
@@ -34,7 +36,7 @@ pub async fn visit(date_time: chrono::DateTime<FixedOffset>) -> Result<Vec<reven
 }
 
 /// 下載月營收
-async fn download_revenue(url: String, year: i32, month: u32) -> Result<Vec<revenue::Revenue>> {
+async fn download_revenue(url: String, year: i32, month: u32) -> Result<Vec<RevenueDto>> {
     let text = util::http::get_use_big5(&url).await?;
     let mut revenues = Vec::with_capacity(1024);
 
@@ -81,9 +83,9 @@ async fn download_revenue(url: String, year: i32, month: u32) -> Result<Vec<reve
             continue;
         }
 
-        let mut entity = revenue::Revenue::from(tds);
-        entity.date = date;
-        revenues.push(entity);
+        let mut dto = RevenueDto::from(tds);
+        dto.date = date;
+        revenues.push(dto);
     }
 
     Ok(revenues)

--- a/src/infra/database/table/quote/daily_quote/mod.rs
+++ b/src/infra/database/table/quote/daily_quote/mod.rs
@@ -1165,17 +1165,18 @@ mod tests {
         logging::debug_file_async("開始 copy_in_raw".to_string());
 
         let date = NaiveDate::from_ymd_opt(2023, 12, 4).unwrap();
-        let mut twse = twse::quote::visit(date).await.unwrap();
-        let date = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
-        for dq in &mut twse {
-            dq.year = date.year();
-            dq.month = date.month() as i32;
-            dq.day = date.day() as i32;
-            dq.date = date;
+        let twse_dtos = twse::quote::visit(date).await.unwrap();
+        let target_date = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+        let mut twse = Vec::new();
+        for mut dto in twse_dtos {
+            dto.date = target_date;
+            let cmd = crate::app::backfill::acl::QuoteAclMapper::to_save_command(&dto);
+            let entity = crate::app::backfill::acl::QuoteAclMapper::to_database_entity(&cmd);
+            twse.push(entity);
         }
 
         let _ = sqlx::query(r#"delete from "DailyQuotes" where "Date" = $1;"#)
-            .bind(date)
+            .bind(target_date)
             .execute(database::get_connection())
             .await;
 


### PR DESCRIPTION
Expands the Anti-Corruption Layer (ACL) mapping to daily quotes (TWSE/TPEx) and monthly revenues (TWSE). Introduces \DailyQuoteDto\ and \RevenueDto\ to completely decouple crawlers from database Table models and database-specific logic. Replaces direct database active record usage in use cases with mapped mappers and commands.