### PR TITLE
refactor: ddd phase 8 - consolidate ACL usage and resolve wrong_self_convention warnings

### DIFF
--- a/src/app/backfill/acl.rs
+++ b/src/app/backfill/acl.rs
@@ -106,6 +106,81 @@ pub struct SaveDailyQuoteCommand {
     pub last_best_ask_volume: Decimal,
 }
 
+/// 儲存大盤加權指數命令。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SaveIndexCommand {
+    /// 日期
+    pub date: NaiveDate,
+    /// 收盤指數
+    pub index: Decimal,
+    /// 漲跌點數
+    pub change: Decimal,
+    /// 成交股數
+    pub trading_volume: Decimal,
+    /// 成交金額
+    pub trade_value: Decimal,
+    /// 成交筆數
+    pub transaction: Decimal,
+}
+
+/// 儲存個股權重命令。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SaveStockWeightCommand {
+    /// 股票代號
+    pub symbol: String,
+    /// 權重百分比
+    pub weight: Decimal,
+}
+
+/// 更新每股淨值命令。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateNetAssetValueCommand {
+    /// 股票代號
+    pub symbol: String,
+    /// 每股淨值
+    pub net_asset_value_per_share: Decimal,
+}
+
+/// 更新股息分配率命令。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdatePayoutRatioCommand {
+    /// 股利資料序號
+    pub serial: i64,
+    /// 現金配發率
+    pub payout_ratio_cash: Decimal,
+    /// 股票配發率
+    pub payout_ratio_stock: Decimal,
+    /// 合計配發率
+    pub payout_ratio: Decimal,
+}
+
+/// 儲存/更新股息明細命令。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SaveDividendCommand {
+    /// 股票代碼
+    pub security_code: String,
+    /// 發放年度
+    pub year: i32,
+    /// 股利所屬年度
+    pub year_of_dividend: i32,
+    /// 季度/半年資訊
+    pub quarter: String,
+    /// 現金股利
+    pub cash_dividend: Decimal,
+    /// 股票股利
+    pub stock_dividend: Decimal,
+    /// 股利合計
+    pub sum: Decimal,
+    /// 除息日
+    pub ex_dividend_date1: String,
+    /// 除權日
+    pub ex_dividend_date2: String,
+    /// 現金股利發放日
+    pub payable_date1: String,
+    /// 股票股利發放日
+    pub payable_date2: String,
+}
+
 /// ISIN 爬蟲資料防腐層轉譯器。
 pub struct IsinAclMapper;
 
@@ -114,7 +189,7 @@ impl IsinAclMapper {
     ///
     /// # 安全防護與過濾
     /// - 若 `industry_id` 為 `0` (代表未分類、非法或解析錯誤的產業資料)，此函式會回傳 `None` 進行過濾阻擋。
-    pub fn to_registration_command(
+    pub fn from_isin(
         dto: &InternationalSecuritiesIdentificationNumber,
     ) -> Option<RegisterStockCommand> {
         // 1. 過濾非法或未分類產業資料 (industry_id == 0)
@@ -141,7 +216,7 @@ impl DelistedCompanyAclMapper {
     /// # 資料清洗與過濾
     /// - 若下市日期格式無效（長度小於 3），回傳 `None`。
     /// - 過濾掉民國 110 年之前的下市資料，以縮小回補與更新範圍。
-    pub fn to_delisted_command(dto: &SuspendListing) -> Option<DelistedCompanyCommand> {
+    pub fn from_suspend_listing(dto: &SuspendListing) -> Option<DelistedCompanyCommand> {
         if dto.delisting_date.len() < 3 {
             return None;
         }
@@ -163,7 +238,7 @@ pub struct QfiiAclMapper;
 
 impl QfiiAclMapper {
     /// 將原始的外資持股資料轉譯成系統內部的 `UpdateQfiiCommand`。
-    pub fn to_update_command(dto: &QualifiedForeignInstitutionalInvestor) -> UpdateQfiiCommand {
+    pub fn from_qfii(dto: &QualifiedForeignInstitutionalInvestor) -> UpdateQfiiCommand {
         UpdateQfiiCommand {
             symbol: dto.stock_symbol.clone(),
             shares_held: dto.qfii_shares_held,
@@ -178,7 +253,7 @@ pub struct EtfAclMapper;
 
 impl EtfAclMapper {
     /// 將原始 ETF DTO 轉譯成 `RegisterStockCommand`。
-    pub fn to_registration_command(dto: &EtfInfo) -> RegisterStockCommand {
+    pub fn from_etf(dto: &EtfInfo) -> RegisterStockCommand {
         RegisterStockCommand {
             symbol: dto.stock_symbol.clone(),
             name: dto.name.clone(),
@@ -193,7 +268,7 @@ pub struct RevenueAclMapper;
 
 impl RevenueAclMapper {
     /// 將原始爬蟲 DTO 轉譯成 `UpdateRevenueCommand`。
-    pub fn to_update_command(dto: &RevenueDto) -> UpdateRevenueCommand {
+    pub fn from_dto(dto: &RevenueDto) -> UpdateRevenueCommand {
         UpdateRevenueCommand {
             symbol: dto.stock_symbol.clone(),
             monthly: dto.monthly,
@@ -209,7 +284,7 @@ impl RevenueAclMapper {
     }
 
     /// 將 `UpdateRevenueCommand` 轉譯為資料庫 Table 模型 `Revenue`。
-    pub fn to_database_entity(
+    pub fn from_command(
         cmd: &UpdateRevenueCommand,
     ) -> crate::infra::database::table::financial::revenue::Revenue {
         use chrono::Local;
@@ -234,7 +309,7 @@ pub struct QuoteAclMapper;
 
 impl QuoteAclMapper {
     /// 將爬蟲 DTO 轉譯成系統內部的 `SaveDailyQuoteCommand`。
-    pub fn to_save_command(dto: &DailyQuoteDto) -> SaveDailyQuoteCommand {
+    pub fn from_dto(dto: &DailyQuoteDto) -> SaveDailyQuoteCommand {
         SaveDailyQuoteCommand {
             symbol: dto.symbol.clone(),
             date: dto.date,
@@ -257,7 +332,7 @@ impl QuoteAclMapper {
     }
 
     /// 將 `SaveDailyQuoteCommand` 轉譯為資料庫 Table 模型 `DailyQuote`。
-    pub fn to_database_entity(
+    pub fn from_command(
         cmd: &SaveDailyQuoteCommand,
     ) -> crate::infra::database::table::daily_quote::DailyQuote {
         use chrono::{Local, TimeZone};
@@ -299,6 +374,192 @@ impl QuoteAclMapper {
     }
 }
 
+/// 大盤加權指數爬蟲資料防腐層轉譯器。
+pub struct IndexAclMapper;
+
+impl IndexAclMapper {
+    /// 將爬蟲取得的大盤原始字串資料列轉譯為 `SaveIndexCommand`。
+    pub fn from_strings(item: &[String]) -> Option<SaveIndexCommand> {
+        if item.len() != 6 {
+            return None;
+        }
+
+        let split_date: Vec<&str> = item[0].split('/').collect();
+        if split_date.len() != 3 {
+            return None;
+        }
+
+        let year = split_date[0].parse::<i32>().ok()?;
+        let gregorian_year = crate::core::util::datetime::roc_year_to_gregorian_year(year);
+        let date_str = format!("{}-{}-{}", gregorian_year, split_date[1], split_date[2]);
+        let date = NaiveDate::parse_from_str(&date_str, "%Y-%m-%d").ok()?;
+
+        let trading_volume = crate::core::util::text::parse_decimal(&item[1], None).ok()?;
+        let trade_value = crate::core::util::text::parse_decimal(&item[2], None).ok()?;
+        let transaction = crate::core::util::text::parse_decimal(&item[3], None).ok()?;
+        let index = crate::core::util::text::parse_decimal(&item[4], None).ok()?;
+        let change = crate::core::util::text::parse_decimal(&item[5], None).ok()?;
+
+        Some(SaveIndexCommand {
+            date,
+            index,
+            change,
+            trading_volume,
+            trade_value,
+            transaction,
+        })
+    }
+
+    /// 將 `SaveIndexCommand` 轉譯為資料庫 Table 模型 `Index`。
+    pub fn from_command(cmd: &SaveIndexCommand) -> crate::infra::database::table::index::Index {
+        use chrono::Local;
+        let mut entity = crate::infra::database::table::index::Index::new();
+        entity.category = "TAIEX".to_string();
+        entity.date = cmd.date;
+        entity.index = cmd.index;
+        entity.change = cmd.change;
+        entity.trading_volume = cmd.trading_volume;
+        entity.trade_value = cmd.trade_value;
+        entity.transaction = cmd.transaction;
+        entity.create_time = Local::now();
+        entity.update_time = Local::now();
+        entity
+    }
+}
+
+/// 個股權重爬蟲資料防腐層轉譯器。
+pub struct StockWeightAclMapper;
+
+impl StockWeightAclMapper {
+    /// 將爬蟲取得的 `StockWeight` 轉譯為 `SaveStockWeightCommand`。
+    pub fn from_dto(
+        dto: &crate::infra::crawler::taifex::stock_weight::StockWeight,
+    ) -> SaveStockWeightCommand {
+        SaveStockWeightCommand {
+            symbol: dto.stock_symbol.clone(),
+            weight: dto.weight,
+        }
+    }
+
+    /// 將 `SaveStockWeightCommand` 轉譯為資料庫 Table 模型 `SymbolAndWeight`。
+    pub fn from_command(
+        cmd: &SaveStockWeightCommand,
+    ) -> crate::infra::database::table::stock::extension::weight::SymbolAndWeight {
+        crate::infra::database::table::stock::extension::weight::SymbolAndWeight::new(
+            cmd.symbol.clone(),
+            cmd.weight,
+        )
+    }
+}
+
+/// 每股淨值爬蟲資料防腐層轉譯器。
+pub struct NetAssetValueAclMapper;
+
+impl NetAssetValueAclMapper {
+    /// 將興櫃 DTO 轉譯為 `UpdateNetAssetValueCommand`。
+    pub fn from_emerging(
+        dto: &crate::infra::crawler::tpex::net_asset_value_per_share::Emerging,
+    ) -> UpdateNetAssetValueCommand {
+        UpdateNetAssetValueCommand {
+            symbol: dto.stock_symbol.clone(),
+            net_asset_value_per_share: dto.net_asset_value_per_share,
+        }
+    }
+
+    /// 將 Yahoo DTO 轉譯為 `UpdateNetAssetValueCommand`。
+    pub fn from_yahoo_profile(
+        symbol: String,
+        dto: &crate::infra::crawler::yahoo::profile::Profile,
+    ) -> UpdateNetAssetValueCommand {
+        UpdateNetAssetValueCommand {
+            symbol,
+            net_asset_value_per_share: dto.net_asset_value_per_share,
+        }
+    }
+}
+
+/// 股息分配率爬蟲資料防腐層轉譯器。
+pub struct DividendAclMapper;
+
+impl DividendAclMapper {
+    /// 將 Goodinfo 股利 DTO 轉譯為 `UpdatePayoutRatioCommand`。
+    pub fn from_dto(
+        serial: i64,
+        dto: &crate::infra::crawler::goodinfo::dividend::GoodInfoDividend,
+    ) -> UpdatePayoutRatioCommand {
+        UpdatePayoutRatioCommand {
+            serial,
+            payout_ratio_cash: dto.payout_ratio_cash,
+            payout_ratio_stock: dto.payout_ratio_stock,
+            payout_ratio: dto.payout_ratio,
+        }
+    }
+
+    /// 將 `UpdatePayoutRatioCommand` 套用至 `PayoutRatioInfo`。
+    pub fn update_payout_ratio_entity(
+        pri: &crate::infra::database::table::dividend::extension::payout_ratio_info::PayoutRatioInfo,
+        cmd: &UpdatePayoutRatioCommand,
+    ) -> crate::infra::database::table::dividend::extension::payout_ratio_info::PayoutRatioInfo
+    {
+        crate::infra::database::table::dividend::extension::payout_ratio_info::PayoutRatioInfo {
+            serial: cmd.serial,
+            year: pri.year,
+            quarter: pri.quarter.clone(),
+            security_code: pri.security_code.clone(),
+            payout_ratio_cash: cmd.payout_ratio_cash,
+            payout_ratio_stock: cmd.payout_ratio_stock,
+            payout_ratio: cmd.payout_ratio,
+        }
+    }
+}
+
+/// Yahoo 股利明細爬蟲資料防腐層轉譯器。
+pub struct YahooDividendAclMapper;
+
+impl YahooDividendAclMapper {
+    /// 將 Yahoo 股利明細 DTO 轉譯為 `SaveDividendCommand`。
+    pub fn from_dto(
+        stock_symbol: &str,
+        dto: &crate::infra::crawler::yahoo::dividend::YahooDividendDetail,
+    ) -> SaveDividendCommand {
+        SaveDividendCommand {
+            security_code: stock_symbol.to_string(),
+            year: dto.year,
+            year_of_dividend: dto.year_of_dividend,
+            quarter: dto.quarter.clone(),
+            cash_dividend: dto.cash_dividend,
+            stock_dividend: dto.stock_dividend,
+            sum: dto.cash_dividend + dto.stock_dividend,
+            ex_dividend_date1: dto.ex_dividend_date1.clone(),
+            ex_dividend_date2: dto.ex_dividend_date2.clone(),
+            payable_date1: dto.payable_date1.clone(),
+            payable_date2: dto.payable_date2.clone(),
+        }
+    }
+
+    /// 將 `SaveDividendCommand` 轉譯為資料庫 Table 模型 `Dividend`。
+    pub fn from_command(
+        cmd: &SaveDividendCommand,
+    ) -> crate::infra::database::table::dividend::Dividend {
+        use chrono::Local;
+        let mut e = crate::infra::database::table::dividend::Dividend::new();
+        e.security_code = cmd.security_code.clone();
+        e.year = cmd.year;
+        e.year_of_dividend = cmd.year_of_dividend;
+        e.quarter = cmd.quarter.clone();
+        e.cash_dividend = cmd.cash_dividend;
+        e.stock_dividend = cmd.stock_dividend;
+        e.sum = cmd.sum;
+        e.ex_dividend_date1 = cmd.ex_dividend_date1.clone();
+        e.ex_dividend_date2 = cmd.ex_dividend_date2.clone();
+        e.payable_date1 = cmd.payable_date1.clone();
+        e.payable_date2 = cmd.payable_date2.clone();
+        e.created_time = Local::now();
+        e.updated_time = Local::now();
+        e
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -318,7 +579,7 @@ mod tests {
             industry_id: 24,
         };
 
-        let cmd = IsinAclMapper::to_registration_command(&isin);
+        let cmd = IsinAclMapper::from_isin(&isin);
         assert!(cmd.is_some());
         let cmd = cmd.unwrap();
         assert_eq!(cmd.symbol, "2330");
@@ -340,7 +601,7 @@ mod tests {
             industry_id: 0,
         };
 
-        let cmd = IsinAclMapper::to_registration_command(&isin);
+        let cmd = IsinAclMapper::from_isin(&isin);
         assert!(cmd.is_none());
     }
 
@@ -352,7 +613,7 @@ mod tests {
             stock_symbol: "9999".to_string(),
         };
 
-        let cmd = DelistedCompanyAclMapper::to_delisted_command(&dto);
+        let cmd = DelistedCompanyAclMapper::from_suspend_listing(&dto);
         assert!(cmd.is_some());
         assert_eq!(cmd.unwrap().symbol, "9999");
     }
@@ -365,7 +626,7 @@ mod tests {
             stock_symbol: "9999".to_string(),
         };
 
-        let cmd = DelistedCompanyAclMapper::to_delisted_command(&dto);
+        let cmd = DelistedCompanyAclMapper::from_suspend_listing(&dto);
         assert!(cmd.is_none(), "應過濾掉民國 110 年之前的下市資料");
     }
 
@@ -377,7 +638,7 @@ mod tests {
             stock_symbol: "9999".to_string(),
         };
 
-        let cmd = DelistedCompanyAclMapper::to_delisted_command(&dto);
+        let cmd = DelistedCompanyAclMapper::from_suspend_listing(&dto);
         assert!(cmd.is_none(), "日期太短應過濾");
     }
 
@@ -390,7 +651,7 @@ mod tests {
             dec!(75.5),
         );
 
-        let cmd = QfiiAclMapper::to_update_command(&dto);
+        let cmd = QfiiAclMapper::from_qfii(&dto);
         assert_eq!(cmd.symbol, "2330");
         assert_eq!(cmd.shares_held, 50000);
         assert_eq!(cmd.share_holding_percentage, dec!(75.5));
@@ -408,7 +669,7 @@ mod tests {
             industry_id: 9001,
         };
 
-        let cmd = EtfAclMapper::to_registration_command(&etf);
+        let cmd = EtfAclMapper::from_etf(&etf);
         assert_eq!(cmd.symbol, "0050");
         assert_eq!(cmd.name, "元大台灣50");
         assert_eq!(cmd.market_id, 2);
@@ -430,12 +691,12 @@ mod tests {
             date: 202605,
         };
 
-        let cmd = RevenueAclMapper::to_update_command(&dto);
+        let cmd = RevenueAclMapper::from_dto(&dto);
         assert_eq!(cmd.symbol, "2330");
         assert_eq!(cmd.monthly, dec!(1000.0));
         assert_eq!(cmd.date, 202605);
 
-        let entity = RevenueAclMapper::to_database_entity(&cmd);
+        let entity = RevenueAclMapper::from_command(&cmd);
         assert_eq!(entity.stock_symbol, "2330");
         assert_eq!(entity.monthly, dec!(1000.0));
         assert_eq!(entity.date, 202605);
@@ -463,13 +724,122 @@ mod tests {
             last_best_ask_volume: dec!(20),
         };
 
-        let cmd = QuoteAclMapper::to_save_command(&dto);
+        let cmd = QuoteAclMapper::from_dto(&dto);
         assert_eq!(cmd.symbol, "2330");
         assert_eq!(cmd.closing_price, dec!(905.0));
 
-        let entity = QuoteAclMapper::to_database_entity(&cmd);
+        let entity = QuoteAclMapper::from_command(&cmd);
         assert_eq!(entity.stock_symbol, "2330");
         assert_eq!(entity.closing_price, dec!(905.0));
         assert_eq!(entity.date, NaiveDate::from_ymd_opt(2026, 6, 5).unwrap());
+    }
+
+    #[test]
+    fn test_index_acl_mapping() {
+        let item = vec![
+            "112/05/20".to_string(), // date
+            "1,234,567".to_string(), // trading_volume
+            "4,567,890".to_string(), // trade_value
+            "100,000".to_string(),   // transaction
+            "16,000.50".to_string(), // index
+            "150.25".to_string(),    // change
+        ];
+
+        let cmd = IndexAclMapper::from_strings(&item);
+        assert!(cmd.is_some());
+        let cmd = cmd.unwrap();
+        assert_eq!(cmd.date, NaiveDate::from_ymd_opt(2023, 5, 20).unwrap());
+        assert_eq!(cmd.index, dec!(16000.50));
+        assert_eq!(cmd.change, dec!(150.25));
+
+        let entity = IndexAclMapper::from_command(&cmd);
+        assert_eq!(entity.category, "TAIEX");
+        assert_eq!(entity.index, dec!(16000.50));
+        assert_eq!(entity.change, dec!(150.25));
+    }
+
+    #[test]
+    fn test_stock_weight_acl_mapping() {
+        let dto = crate::infra::crawler::taifex::stock_weight::StockWeight {
+            rank: 1,
+            stock_symbol: "2330".to_string(),
+            weight: dec!(28.5),
+        };
+
+        let cmd = StockWeightAclMapper::from_dto(&dto);
+        assert_eq!(cmd.symbol, "2330");
+        assert_eq!(cmd.weight, dec!(28.5));
+
+        let entity = StockWeightAclMapper::from_command(&cmd);
+        assert_eq!(entity.stock_symbol, "2330");
+        assert_eq!(entity.weight, dec!(28.5));
+    }
+
+    #[test]
+    fn test_net_asset_value_acl_mapping() {
+        let emerging = crate::infra::crawler::tpex::net_asset_value_per_share::Emerging {
+            stock_symbol: "6987".to_string(),
+            net_asset_value_per_share: dec!(42.19),
+        };
+        let cmd1 = NetAssetValueAclMapper::from_emerging(&emerging);
+        assert_eq!(cmd1.symbol, "6987");
+        assert_eq!(cmd1.net_asset_value_per_share, dec!(42.19));
+
+        let profile = crate::infra::crawler::yahoo::profile::Profile {
+            net_asset_value_per_share: dec!(95.12),
+            ..Default::default()
+        };
+        let cmd2 = NetAssetValueAclMapper::from_yahoo_profile("2330".to_string(), &profile);
+        assert_eq!(cmd2.symbol, "2330");
+        assert_eq!(cmd2.net_asset_value_per_share, dec!(95.12));
+    }
+
+    #[test]
+    fn test_dividend_acl_mapping() {
+        let mut goodinfo =
+            crate::infra::crawler::goodinfo::dividend::GoodInfoDividend::new("2330".to_string());
+        goodinfo.payout_ratio_cash = dec!(45.5);
+        goodinfo.payout_ratio_stock = dec!(0.0);
+        goodinfo.payout_ratio = dec!(45.5);
+
+        let cmd = DividendAclMapper::from_dto(123, &goodinfo);
+        assert_eq!(cmd.serial, 123);
+        assert_eq!(cmd.payout_ratio_cash, dec!(45.5));
+
+        let mut pri = crate::infra::database::table::dividend::extension::payout_ratio_info::PayoutRatioInfo {
+            serial: 123,
+            year: 2024,
+            quarter: "Q4".to_string(),
+            security_code: "2330".to_string(),
+            payout_ratio_cash: dec!(0.0),
+            payout_ratio_stock: dec!(0.0),
+            payout_ratio: dec!(0.0),
+        };
+        pri = DividendAclMapper::update_payout_ratio_entity(&pri, &cmd);
+        assert_eq!(pri.payout_ratio_cash, dec!(45.5));
+    }
+
+    #[test]
+    fn test_yahoo_dividend_acl_mapping() {
+        let detail = crate::infra::crawler::yahoo::dividend::YahooDividendDetail {
+            year: 2025,
+            year_of_dividend: 2024,
+            quarter: "Q4".to_string(),
+            cash_dividend: dec!(3.5),
+            stock_dividend: dec!(0.2),
+            ex_dividend_date1: "2025-07-01".to_string(),
+            ex_dividend_date2: "-".to_string(),
+            payable_date1: "2025-08-01".to_string(),
+            payable_date2: "-".to_string(),
+        };
+
+        let cmd = YahooDividendAclMapper::from_dto("2454", &detail);
+        assert_eq!(cmd.security_code, "2454");
+        assert_eq!(cmd.sum, dec!(3.7));
+
+        let entity = YahooDividendAclMapper::from_command(&cmd);
+        assert_eq!(entity.security_code, "2454");
+        assert_eq!(entity.sum, dec!(3.7));
+        assert_eq!(entity.ex_dividend_date1, "2025-07-01");
     }
 }

--- a/src/app/backfill/delisted_company.rs
+++ b/src/app/backfill/delisted_company.rs
@@ -21,7 +21,7 @@ pub async fn execute() -> Result<()> {
 
     for company in delisted {
         // 透過防腐層轉譯為內部命令，內含格式與民國年分過濾邏輯
-        if let Some(cmd) = DelistedCompanyAclMapper::to_delisted_command(&company) {
+        if let Some(cmd) = DelistedCompanyAclMapper::from_suspend_listing(&company) {
             if let Some(stock) = repo.find_by_symbol(&cmd.symbol).await? {
                 if stock.suspend_listing() {
                     continue;

--- a/src/app/backfill/dividend/missing_or_multiple.rs
+++ b/src/app/backfill/dividend/missing_or_multiple.rs
@@ -3,11 +3,10 @@ use std::{collections::HashSet, time::Duration};
 use rand::RngExt;
 
 use crate::{
-    app::calculation::dividend_record, core::logging, core::util::map::Keyable,
-    infra::crawler::yahoo, infra::database::table::dividend,
+    app::backfill::acl::YahooDividendAclMapper, app::calculation::dividend_record, core::logging,
+    core::util::map::Keyable, infra::crawler::yahoo, infra::database::table::dividend,
 };
 use anyhow::{Context, Result};
-use chrono::Local;
 
 /// 歷年股利批次回補的執行結果。
 ///
@@ -132,8 +131,8 @@ pub async fn backfill_historical_dividends_for_stock(stock_symbol: &str) -> Resu
     // Yahoo 已依發放年度分組；歷年回補不篩年度，所有明細都要依來源資料寫回。
     for (paid_year, dividend_details_from_yahoo) in &dividends_from_yahoo.dividend {
         for dividend_from_yahoo in dividend_details_from_yahoo {
-            // 將 Yahoo 的欄位映射成 dividend 表欄位，保留日期與每股股利數值。
-            let entity = yahoo_dividend_to_entity(stock_symbol, dividend_from_yahoo);
+            let cmd = YahooDividendAclMapper::from_dto(stock_symbol, dividend_from_yahoo);
+            let entity = YahooDividendAclMapper::from_command(&cmd);
             entity.upsert().await.with_context(|| {
                 format!(
                     "historical dividend upsert failed: stock_symbol={}, paid_year={}, year_of_dividend={}, quarter={}",
@@ -285,8 +284,8 @@ async fn backfill_recent_dividends_for_stock(
                 continue;
             }
 
-            // 將 Yahoo 明細映射成資料表實體；Yahoo 沒有提供的細項欄位會保留預設值。
-            let entity = yahoo_dividend_to_entity(stock_symbol, dividend_from_yahoo);
+            let cmd = YahooDividendAclMapper::from_dto(stock_symbol, dividend_from_yahoo);
+            let entity = YahooDividendAclMapper::from_command(&cmd);
             match entity.upsert().await {
                 Ok(_) => {
                     logging::debug_file_async(format!(
@@ -352,44 +351,9 @@ fn make_cache_key(stock_symbol: &str) -> String {
     format!("yahoo:dividend:{stock_symbol}")
 }
 
-/// 將 Yahoo 股利明細轉成資料庫 `Dividend` 實體。
-///
-/// Yahoo 來源提供發放年度、股利所屬年度、季度、現金/股票股利與日期欄位；盈餘/公積拆分與
-/// 盈餘分配率在此來源沒有資料，因此沿用 `Dividend::new()` 的預設值。`sum` 由現金股利加上
-/// 股票股利計算，時間欄位使用本地現在時間。
-fn yahoo_dividend_to_entity(
-    stock_symbol: &str,
-    d: &yahoo::dividend::YahooDividendDetail,
-) -> dividend::Dividend {
-    // 先建立預設實體，讓 Yahoo 沒提供的盈餘/公積拆分與分配率維持 0。
-    let mut e = dividend::Dividend::new();
-    // 股票代號由呼叫端傳入，避免依賴 Yahoo 明細內部是否重複保存代號。
-    e.security_code = stock_symbol.to_string();
-    // `year` 是實際發放年度，會用於除權息提醒與年度彙總聚合。
-    e.year = d.year;
-    // `year_of_dividend` 是股利所屬年度，例如 2024Q4 可能在 2025 發放。
-    e.year_of_dividend = d.year_of_dividend;
-    // 季度空字串代表年度配息；Q/H 代表季配或半年配。
-    e.quarter = d.quarter.clone();
-    // Yahoo 已提供合計後的現金股利與股票股利，直接保留 Decimal 精度。
-    e.cash_dividend = d.cash_dividend;
-    e.stock_dividend = d.stock_dividend;
-    // 資料表的 `sum` 為每股現金股利與每股股票股利的合計。
-    e.sum = d.cash_dividend + d.stock_dividend;
-    // 日期欄位可能是實際日期或 `-`；此流程照來源保存，未公布日期由另一條回補流程處理。
-    e.ex_dividend_date1 = d.ex_dividend_date1.clone();
-    e.ex_dividend_date2 = d.ex_dividend_date2.clone();
-    e.payable_date1 = d.payable_date1.clone();
-    e.payable_date2 = d.payable_date2.clone();
-    // 新增與更新時間都用目前本地時間，讓後續可以追蹤本次回補寫入時間。
-    e.created_time = Local::now();
-    e.updated_time = Local::now();
-    e
-}
-
 #[cfg(test)]
 mod tests {
-    use chrono::Datelike;
+    use chrono::{Datelike, Local};
     use rust_decimal_macros::dec;
 
     use super::*;
@@ -423,7 +387,8 @@ mod tests {
             payable_date2: "2025-08-02".to_string(),
         };
 
-        let e = yahoo_dividend_to_entity("2454", &d);
+        let cmd = YahooDividendAclMapper::from_dto("2454", &d);
+        let e = YahooDividendAclMapper::from_command(&cmd);
         assert_eq!(e.security_code, "2454");
         assert_eq!(e.year, 2025);
         assert_eq!(e.year_of_dividend, 2024);

--- a/src/app/backfill/dividend/payout_ratio.rs
+++ b/src/app/backfill/dividend/payout_ratio.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashSet, time::Duration};
 
 use crate::{
+    app::backfill::acl::DividendAclMapper,
     core::logging,
     core::util::map::{vec_to_hashmap, Keyable},
     infra::crawler::goodinfo,
@@ -48,21 +49,21 @@ pub async fn execute() -> Result<()> {
             for gd in gds {
                 let key = gd.key();
                 if let Some(pri) = dividend_without_payout_ratio.get_mut(&key) {
-                    pri.payout_ratio = gd.payout_ratio;
-                    pri.payout_ratio_stock = gd.payout_ratio_stock;
-                    pri.payout_ratio_cash = gd.payout_ratio_cash;
+                    let cmd = DividendAclMapper::from_dto(pri.serial, &gd);
+                    let updated_pri = DividendAclMapper::update_payout_ratio_entity(pri, &cmd);
 
-                    match pri.update().await {
+                    match updated_pri.update().await {
                         Ok(_) => {
                             logging::info_file_async(format!(
                                 "更新盈餘分配率成功: security_code={}, year_of_dividend={}, quarter={}, payout_ratio_cash={}, payout_ratio_stock={}, payout_ratio={}",
-                                pri.security_code,
-                                pri.year,
-                                pri.quarter,
-                                pri.payout_ratio_cash,
-                                pri.payout_ratio_stock,
-                                pri.payout_ratio
+                                updated_pri.security_code,
+                                updated_pri.year,
+                                updated_pri.quarter,
+                                updated_pri.payout_ratio_cash,
+                                updated_pri.payout_ratio_stock,
+                                updated_pri.payout_ratio
                             ));
+                            *pri = updated_pri;
                         }
                         Err(why) => {
                             logging::error_file_async(format!("{} {:?}", key, why));

--- a/src/app/backfill/dividend/unannounced_ex_dividend_date.rs
+++ b/src/app/backfill/dividend/unannounced_ex_dividend_date.rs
@@ -5,7 +5,10 @@ use tokio_retry::{
     Retry,
 };
 
-use crate::{core::logging, infra::crawler::yahoo, infra::database::table::dividend};
+use crate::{
+    app::backfill::acl::YahooDividendAclMapper, core::logging, infra::crawler::yahoo,
+    infra::database::table::dividend,
+};
 
 /// 回補除息/發放日期尚未公布的股利資料。
 ///
@@ -103,10 +106,12 @@ async fn backfill_unannounced_dividend_dates_from_yahoo(
         if let Some(yahoo_dividend_detail) =
             find_changed_dividend_detail(yahoo_dividend_details, &entity)
         {
-            entity.ex_dividend_date1 = yahoo_dividend_detail.ex_dividend_date1.to_string();
-            entity.ex_dividend_date2 = yahoo_dividend_detail.ex_dividend_date2.to_string();
-            entity.payable_date1 = yahoo_dividend_detail.payable_date1.to_string();
-            entity.payable_date2 = yahoo_dividend_detail.payable_date2.to_string();
+            let cmd =
+                YahooDividendAclMapper::from_dto(&entity.security_code, yahoo_dividend_detail);
+            entity.ex_dividend_date1 = cmd.ex_dividend_date1;
+            entity.ex_dividend_date2 = cmd.ex_dividend_date2;
+            entity.payable_date1 = cmd.payable_date1;
+            entity.payable_date2 = cmd.payable_date2;
 
             if let Err(why) = entity.update_dividend_date().await {
                 return Err(anyhow!("{}", why));

--- a/src/app/backfill/etf.rs
+++ b/src/app/backfill/etf.rs
@@ -48,7 +48,7 @@ async fn update_stocks(items: Vec<EtfInfo>) -> Result<()> {
         .await;
 
         if is_new_or_changed {
-            let cmd = EtfAclMapper::to_registration_command(&item);
+            let cmd = EtfAclMapper::from_etf(&item);
             if let Err(why) = update_stock_info(&cmd).await {
                 logging::error_file_async(format!(
                     "更新 ETF {} 資訊失敗: {:?}",

--- a/src/app/backfill/isin.rs
+++ b/src/app/backfill/isin.rs
@@ -70,7 +70,7 @@ async fn process_market(mode: StockExchangeMarket) -> Result<()> {
     let result = twse::international_securities_identification_number::visit(mode).await?;
     for item in result {
         // 透過防腐層 (ACL) Mapper 將外部爬蟲 DTO 轉換為內部指令
-        let cmd = match backfill::acl::IsinAclMapper::to_registration_command(&item) {
+        let cmd = match backfill::acl::IsinAclMapper::from_isin(&item) {
             Some(c) => c,
             None => continue, // 過濾無效或未分類的資料 (如 industry_id == 0)
         };

--- a/src/app/backfill/net_asset_value_per_share/emerging.rs
+++ b/src/app/backfill/net_asset_value_per_share/emerging.rs
@@ -1,7 +1,7 @@
 use crate::{
-    app::backfill::net_asset_value_per_share::update, core::logging, core::util::datetime::Weekend,
-    domain::registry::repository::StockRepository, infra::crawler::tpex,
-    infra::database::repository::stock::PgStockRepository,
+    app::backfill::acl::NetAssetValueAclMapper, app::backfill::net_asset_value_per_share::update,
+    core::logging, core::util::datetime::Weekend, domain::registry::repository::StockRepository,
+    infra::crawler::tpex, infra::database::repository::stock::PgStockRepository,
 };
 use anyhow::Result;
 use chrono::Local;
@@ -22,31 +22,19 @@ pub async fn execute() -> Result<()> {
     let repo = PgStockRepository::new();
 
     for item in result {
-        let stock_cache = repo.find_by_symbol(&item.stock_symbol).await?;
+        let cmd = NetAssetValueAclMapper::from_emerging(&item);
+        let stock_cache = repo.find_by_symbol(&cmd.symbol).await?;
         let stock = match stock_cache {
             None => continue,
             Some(stock_cache) => {
-                if stock_cache.net_asset_value_per_share() == item.net_asset_value_per_share {
+                if stock_cache.net_asset_value_per_share() == cmd.net_asset_value_per_share {
                     continue;
                 }
                 let mut s = stock_cache.clone();
-                s.update_net_asset_value(item.net_asset_value_per_share);
+                s.update_net_asset_value(cmd.net_asset_value_per_share);
                 s
             }
         };
-
-        /*
-        let stock = match SHARE.stocks.read() {
-            Ok(stocks_cache) => {
-                if let Some(stock_cache) = stocks_cache.get(item.stock_symbol.as_str()) {
-                    if stock_cache.net_asset_value_per_share == item.net_asset_value_per_share {
-                        continue;
-                    }
-                }
-                table::stock::Stock::from(item)
-            }
-            Err(_) => continue,
-        };*/
 
         match update(&stock).await {
             Ok(_) => {

--- a/src/app/backfill/net_asset_value_per_share/zero_value.rs
+++ b/src/app/backfill/net_asset_value_per_share/zero_value.rs
@@ -1,6 +1,6 @@
 use crate::{
-    app::backfill::net_asset_value_per_share::update, core::logging,
-    infra::crawler::yahoo::profile, infra::database::table,
+    app::backfill::acl::NetAssetValueAclMapper, app::backfill::net_asset_value_per_share::update,
+    core::logging, infra::crawler::yahoo::profile, infra::database::table,
 };
 use anyhow::Result;
 
@@ -57,7 +57,10 @@ pub async fn execute() -> Result<()> {
             }
         };
 
-        if yahoo_profile.net_asset_value_per_share.is_zero() {
+        let cmd =
+            NetAssetValueAclMapper::from_yahoo_profile(stock.symbol().0.clone(), &yahoo_profile);
+
+        if cmd.net_asset_value_per_share.is_zero() {
             logging::info_file_async(format!(
                 "the stock's net_asset_value_per_share is zero still. \r\n{:#?}",
                 yahoo_profile
@@ -65,7 +68,7 @@ pub async fn execute() -> Result<()> {
             continue;
         }
 
-        stock.update_net_asset_value(yahoo_profile.net_asset_value_per_share);
+        stock.update_net_asset_value(cmd.net_asset_value_per_share);
 
         if let Err(why) = update(&stock).await {
             logging::error_file_async(format!(

--- a/src/app/backfill/qualified_foreign_institutional_investor.rs
+++ b/src/app/backfill/qualified_foreign_institutional_investor.rs
@@ -29,17 +29,14 @@ pub async fn execute() -> Result<()> {
 
 async fn listed(date_time: DateTime<FixedOffset>) -> Result<()> {
     let listed = twse::qualified_foreign_institutional_investor::listed::visit(date_time).await?;
-    let cmds = listed
-        .iter()
-        .map(QfiiAclMapper::to_update_command)
-        .collect();
+    let cmds = listed.iter().map(QfiiAclMapper::from_qfii).collect();
     update(cmds).await
 }
 
 /// 回補上櫃外資持股資料。
 async fn otc() -> Result<()> {
     let toc = twse::qualified_foreign_institutional_investor::over_the_counter::visit().await?;
-    let cmds = toc.iter().map(QfiiAclMapper::to_update_command).collect();
+    let cmds = toc.iter().map(QfiiAclMapper::from_qfii).collect();
     update(cmds).await
 }
 

--- a/src/app/backfill/quote.rs
+++ b/src/app/backfill/quote.rs
@@ -63,11 +63,8 @@ pub async fn get_quotes_from_source(
 
 /// 將收盤價整批寫入資料庫並更新主快取。
 pub async fn process_quotes(quotes: Vec<DailyQuoteDto>) {
-    let cmds: Vec<_> = quotes.iter().map(QuoteAclMapper::to_save_command).collect();
-    let entities: Vec<_> = cmds
-        .iter()
-        .map(QuoteAclMapper::to_database_entity)
-        .collect();
+    let cmds: Vec<_> = quotes.iter().map(QuoteAclMapper::from_dto).collect();
+    let entities: Vec<_> = cmds.iter().map(QuoteAclMapper::from_command).collect();
 
     let result_count = table::daily_quote::DailyQuote::copy_in_raw(&entities)
         .await

--- a/src/app/backfill/revenue.rs
+++ b/src/app/backfill/revenue.rs
@@ -35,10 +35,7 @@ async fn process_revenues(last_month_timezone: chrono::DateTime<FixedOffset>) ->
     let month = last_month_timezone.month();
 
     let revenues = twse::revenue::visit(last_month_timezone).await?;
-    let cmds: Vec<UpdateRevenueCommand> = revenues
-        .iter()
-        .map(RevenueAclMapper::to_update_command)
-        .collect();
+    let cmds: Vec<UpdateRevenueCommand> = revenues.iter().map(RevenueAclMapper::from_dto).collect();
 
     stream::iter(cmds)
         .for_each_concurrent(util::concurrent_limit_16(), |cmd| async move {
@@ -58,7 +55,7 @@ pub(crate) async fn process_revenue(
     year: i32,
     month: i32,
 ) -> Result<()> {
-    let mut revenue_entity = RevenueAclMapper::to_database_entity(&cmd);
+    let mut revenue_entity = RevenueAclMapper::from_command(&cmd);
 
     if let Ok(dq) =
         table::daily_quote::fetch_monthly_stock_price_summary(&cmd.symbol, year, month).await

--- a/src/app/backfill/stock_weight.rs
+++ b/src/app/backfill/stock_weight.rs
@@ -6,11 +6,9 @@ use scopeguard::defer;
 use tokio::sync::Mutex;
 
 use crate::{
-    core::declare::StockExchange,
-    core::logging,
-    core::util,
-    infra::crawler::taifex,
-    infra::database::table::stock::{self, extension::weight::SymbolAndWeight},
+    app::backfill::acl::StockWeightAclMapper, core::declare::StockExchange, core::logging,
+    core::util, infra::crawler::taifex,
+    infra::database::table::stock::extension::weight::SymbolAndWeight,
 };
 
 /// 查詢 taifex 個股權值比重
@@ -58,7 +56,15 @@ async fn handle_stock_exchange(
     let res = taifex::stock_weight::visit(exchange)
         .await
         .with_context(|| format!("Failed to visit taifex for exchange {:?}", exchange))?;
-    let new_weights = stock::extension::weight::from(res);
+
+    let new_weights: Vec<SymbolAndWeight> = res
+        .into_iter()
+        .map(|dto| {
+            let cmd = StockWeightAclMapper::from_dto(&dto);
+            StockWeightAclMapper::from_command(&cmd)
+        })
+        .collect();
+
     let mut weights = stock_weights.lock().await;
 
     weights.extend(new_weights);

--- a/src/app/backfill/taiwan_stock_index.rs
+++ b/src/app/backfill/taiwan_stock_index.rs
@@ -1,33 +1,11 @@
 use anyhow::Result;
 use chrono::{Local, NaiveDate, TimeZone};
 
-use crate::core::util::map::Keyable;
-use crate::interfaces::bot::telegram::Telegram;
-use crate::{
-    core::logging, infra::cache::SHARE, infra::crawler::twse, infra::database::table,
-    interfaces::bot,
-};
+use crate::app::backfill::acl::IndexAclMapper;
+use crate::app::event::handlers::get_global_dispatcher;
+use crate::domain::events::DomainEvent;
+use crate::{core::logging, infra::cache::SHARE, infra::crawler::twse};
 
-/// 解析單筆指數字串陣列。若格式錯誤或解析失敗，會記錄 error log 並回傳 `None`。
-fn parse_index_item(item: &[String]) -> Option<table::index::Index> {
-    if item.len() != 6 {
-        logging::error_file_async(format!("資料欄位不等於6 item:{:?}", item));
-        return None;
-    }
-
-    match table::index::Index::from_strings(item) {
-        Ok(i) => Some(i),
-        Err(why) => {
-            logging::error_file_async(format!(
-                "Failed to index::Index::from_strings({:?}) because {:?}",
-                item, why
-            ));
-            None
-        }
-    }
-}
-
-/// 調用  twse API 取得台股加權指數（使用目前日期）
 pub async fn execute() -> Result<()> {
     let tai_ex = twse::taiwan_capitalization_weighted_stock_index::visit(Local::now()).await?;
     if tai_ex.stat.to_uppercase() != "OK" {
@@ -37,35 +15,37 @@ pub async fn execute() -> Result<()> {
 
     if let Some(data) = tai_ex.data {
         for item in data {
-            let index = match parse_index_item(&item) {
-                Some(i) => i,
+            let cmd = match IndexAclMapper::from_strings(&item) {
+                Some(c) => c,
                 None => continue,
             };
 
-            //logging::debug_file_async(format!("index:{:?}", index));
-            let key = index.key();
+            let key = format!("{}-TAIEX", cmd.date);
             if SHARE.get_stock_index(&key).is_some() {
                 continue;
             }
 
-            match index.upsert().await {
+            let index_entity = IndexAclMapper::from_command(&cmd);
+
+            match index_entity.upsert().await {
                 Ok(_) => {
-                    logging::info_file_async(format!("index add {:?}", index));
-                    let msg = format!(
-                        "{} 大盤指數︰{} 漲跌︰{}",
-                        Telegram::escape_markdown_v2(index.date.to_string()),
-                        Telegram::escape_markdown_v2(index.index.to_string()),
-                        Telegram::escape_markdown_v2(index.change.to_string())
-                    );
+                    logging::info_file_async(format!("index add {:?}", index_entity));
 
-                    bot::telegram::send(&msg).await;
+                    // 派發領域事件以發送 Telegram 通知
+                    let event = DomainEvent::StockIndexUpdated {
+                        date: cmd.date,
+                        index: cmd.index,
+                        change: cmd.change,
+                        occurred_at: Local::now(),
+                    };
+                    get_global_dispatcher().dispatch_async(vec![event]).await;
 
-                    SHARE.set_stock_index(key, index).await;
+                    SHARE.set_stock_index(key, index_entity).await;
                 }
                 Err(why) => {
                     logging::error_file_async(format!(
                         "Failed to index.upsert({:#?}) because {:?}",
-                        index, why
+                        index_entity, why
                     ));
                 }
             }
@@ -105,27 +85,29 @@ pub async fn execute_for_date(date: NaiveDate) -> Result<usize> {
 
     if let Some(data) = tai_ex.data {
         for item in data {
-            let index = match parse_index_item(&item) {
-                Some(i) => i,
+            let cmd = match IndexAclMapper::from_strings(&item) {
+                Some(c) => c,
                 None => continue,
             };
 
             // TWSE 回傳整月資料，只處理與指定日期相符的那一筆。
-            if index.date != date {
+            if cmd.date != date {
                 continue;
             }
 
-            match index.upsert().await {
+            let index_entity = IndexAclMapper::from_command(&cmd);
+
+            match index_entity.upsert().await {
                 Ok(_) => {
-                    logging::info_file_async(format!("index upsert (backfill) {:?}", index));
-                    let key = index.key();
-                    SHARE.set_stock_index(key, index).await;
+                    logging::info_file_async(format!("index upsert (backfill) {:?}", index_entity));
+                    let key = format!("{}-TAIEX", index_entity.date);
+                    SHARE.set_stock_index(key, index_entity).await;
                     upserted_count += 1;
                 }
                 Err(why) => {
                     logging::error_file_async(format!(
                         "Failed to index.upsert({:#?}) because {:?}",
-                        index, why
+                        index_entity, why
                     ));
                 }
             }

--- a/src/app/event/handlers.rs
+++ b/src/app/event/handlers.rs
@@ -224,6 +224,20 @@ impl EventDispatcher {
             DomainEvent::NetAssetValueUpdated { .. } => {
                 // 目前每股淨值更新不需要額外副作用
             }
+            DomainEvent::StockIndexUpdated {
+                date,
+                index,
+                change,
+                ..
+            } => {
+                let msg = format!(
+                    "{} 大盤指數︰{} 漲跌︰{}",
+                    Telegram::escape_markdown_v2(date.to_string()),
+                    Telegram::escape_markdown_v2(index.to_string()),
+                    Telegram::escape_markdown_v2(change.to_string())
+                );
+                debouncer.add_message(msg).await;
+            }
         }
 
         Ok(())
@@ -394,6 +408,39 @@ mod tests {
             assert_eq!(new_nav, dec!(95.12));
         } else {
             panic!("Expected NetAssetValueUpdated event");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_stock_index_updated_event() {
+        let event_log = Arc::new(Mutex::new(Vec::new()));
+        let dispatcher =
+            EventDispatcher::new_with_handler(Some(fake_handler(event_log.clone())), 10);
+
+        let events = vec![DomainEvent::StockIndexUpdated {
+            date: chrono::NaiveDate::from_ymd_opt(2026, 6, 7).unwrap(),
+            index: dec!(16500.25),
+            change: dec!(120.50),
+            occurred_at: chrono::Local::now(),
+        }];
+
+        dispatcher.dispatch_async(events).await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        let log = event_log.lock().await;
+        assert_eq!(log.len(), 1);
+        if let DomainEvent::StockIndexUpdated {
+            date,
+            index,
+            change,
+            ..
+        } = log[0]
+        {
+            assert_eq!(date, chrono::NaiveDate::from_ymd_opt(2026, 6, 7).unwrap());
+            assert_eq!(index, dec!(16500.25));
+            assert_eq!(change, dec!(120.50));
+        } else {
+            panic!("Expected StockIndexUpdated event");
         }
     }
 

--- a/src/app/event/trace/stats.rs
+++ b/src/app/event/trace/stats.rs
@@ -272,33 +272,40 @@ mod tests {
             TraceRuntimeStatsSnapshot::default()
         ));
 
-        let mut snapshot = TraceRuntimeStatsSnapshot::default();
-        snapshot.price_events_published = 1;
-        assert!(has_any_runtime_activity(snapshot));
+        assert!(has_any_runtime_activity(TraceRuntimeStatsSnapshot {
+            price_events_published: 1,
+            ..Default::default()
+        }));
 
-        snapshot = TraceRuntimeStatsSnapshot::default();
-        snapshot.price_events_dropped = 1;
-        assert!(has_any_runtime_activity(snapshot));
+        assert!(has_any_runtime_activity(TraceRuntimeStatsSnapshot {
+            price_events_dropped: 1,
+            ..Default::default()
+        }));
 
-        snapshot = TraceRuntimeStatsSnapshot::default();
-        snapshot.price_events_consumed = 1;
-        assert!(has_any_runtime_activity(snapshot));
+        assert!(has_any_runtime_activity(TraceRuntimeStatsSnapshot {
+            price_events_consumed: 1,
+            ..Default::default()
+        }));
 
-        snapshot = TraceRuntimeStatsSnapshot::default();
-        snapshot.notifications_sent = 1;
-        assert!(has_any_runtime_activity(snapshot));
+        assert!(has_any_runtime_activity(TraceRuntimeStatsSnapshot {
+            notifications_sent: 1,
+            ..Default::default()
+        }));
 
-        snapshot = TraceRuntimeStatsSnapshot::default();
-        snapshot.reconciliation_runs = 1;
-        assert!(has_any_runtime_activity(snapshot));
+        assert!(has_any_runtime_activity(TraceRuntimeStatsSnapshot {
+            reconciliation_runs: 1,
+            ..Default::default()
+        }));
 
-        snapshot = TraceRuntimeStatsSnapshot::default();
-        snapshot.reconciliation_symbols_scanned = 1;
-        assert!(has_any_runtime_activity(snapshot));
+        assert!(has_any_runtime_activity(TraceRuntimeStatsSnapshot {
+            reconciliation_symbols_scanned: 1,
+            ..Default::default()
+        }));
 
-        snapshot = TraceRuntimeStatsSnapshot::default();
-        snapshot.reconciliation_alert_hits = 1;
-        assert!(has_any_runtime_activity(snapshot));
+        assert!(has_any_runtime_activity(TraceRuntimeStatsSnapshot {
+            reconciliation_alert_hits: 1,
+            ..Default::default()
+        }));
     }
 
     #[test]

--- a/src/domain/events.rs
+++ b/src/domain/events.rs
@@ -58,4 +58,18 @@ pub enum DomainEvent {
         /// 事件發生時間
         occurred_at: DateTime<Local>,
     },
+
+    /// <summary>
+    /// 當大盤指數更新時觸發。
+    /// </summary>
+    StockIndexUpdated {
+        /// 指數日期
+        date: chrono::NaiveDate,
+        /// 收盤指數值
+        index: Decimal,
+        /// 漲跌點數
+        change: Decimal,
+        /// 事件發生時間
+        occurred_at: DateTime<Local>,
+    },
 }

--- a/src/infra/crawler/twse/taiwan_capitalization_weighted_stock_index.rs
+++ b/src/infra/crawler/twse/taiwan_capitalization_weighted_stock_index.rs
@@ -7,7 +7,7 @@ use crate::{core::util, infra::crawler::twse};
 /// 調用台股指數 twse API 後其回應的數據
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 //#[serde(rename_all = "camelCase")]
-pub struct Index {
+pub struct TaiwanStockIndexDto {
     /// API 回應狀態。
     pub stat: String,
     /// 查詢日期。
@@ -21,7 +21,7 @@ pub struct Index {
 }
 
 /// 取得台股指數
-pub async fn visit(date: DateTime<Local>) -> Result<Index> {
+pub async fn visit(date: DateTime<Local>) -> Result<TaiwanStockIndexDto> {
     let url = format!(
         "https://www.{}/exchangeReport/FMTQIK?response=json&date={}&_={}",
         twse::HOST,
@@ -29,7 +29,7 @@ pub async fn visit(date: DateTime<Local>) -> Result<Index> {
         date.timestamp_millis()
     );
 
-    util::http::get_json::<Index>(&url).await
+    util::http::get_json::<TaiwanStockIndexDto>(&url).await
 }
 
 #[cfg(test)]

--- a/src/infra/database/table/quote/daily_quote/mod.rs
+++ b/src/infra/database/table/quote/daily_quote/mod.rs
@@ -1170,8 +1170,8 @@ mod tests {
         let mut twse = Vec::new();
         for mut dto in twse_dtos {
             dto.date = target_date;
-            let cmd = crate::app::backfill::acl::QuoteAclMapper::to_save_command(&dto);
-            let entity = crate::app::backfill::acl::QuoteAclMapper::to_database_entity(&cmd);
+            let cmd = crate::app::backfill::acl::QuoteAclMapper::from_dto(&dto);
+            let entity = crate::app::backfill::acl::QuoteAclMapper::from_command(&cmd);
             twse.push(entity);
         }
 

--- a/src/infra/database/table/stock/extension/weight.rs
+++ b/src/infra/database/table/stock/extension/weight.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context, Result};
 use rust_decimal::Decimal;
 use sqlx::{postgres::PgQueryResult, FromRow};
 
-use crate::{infra::crawler::taifex::stock_weight::StockWeight, infra::database};
+use crate::infra::database;
 
 /// 更新股票的權重
 #[derive(FromRow, Debug, Clone)]
@@ -11,19 +11,6 @@ pub struct SymbolAndWeight {
     pub stock_symbol: String,
     /// 權值占比。
     pub weight: Decimal,
-}
-
-//let entity: Entity = fs.into(); // 或者 let entity = Entity::from(fs);
-impl From<StockWeight> for SymbolAndWeight {
-    fn from(stock_weight: StockWeight) -> Self {
-        SymbolAndWeight::new(stock_weight.stock_symbol, stock_weight.weight)
-    }
-}
-
-// 新增一個方法來將 StockWeight 轉換成 SymbolAndWeight
-/// 批次將 `StockWeight` 轉為 `SymbolAndWeight`。
-pub fn from(weights: Vec<StockWeight>) -> Vec<SymbolAndWeight> {
-    weights.into_iter().map(SymbolAndWeight::from).collect()
 }
 
 impl SymbolAndWeight {
@@ -86,13 +73,7 @@ mod tests {
     async fn test_update() {
         dotenv::dotenv().ok();
         logging::debug_file_async("開始 update".to_string());
-        let stock_weight = StockWeight {
-            rank: 0,
-            stock_symbol: "2330".to_string(),
-            weight: dec!(28.3278),
-        };
-
-        let sw = SymbolAndWeight::from(stock_weight);
+        let sw = SymbolAndWeight::new("2330".to_string(), dec!(28.3278));
         match sw.update().await {
             Ok(_qr) => {
                 let sql = r#"

--- a/src/infra/database/table/stock/mod.rs
+++ b/src/infra/database/table/stock/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     core::declare::Industry,
     core::logging,
     core::util::{self, map::Keyable},
-    infra::crawler::{tpex, twse},
+    infra::crawler::twse,
     infra::database,
 };
 
@@ -327,24 +327,6 @@ impl From<twse::international_securities_identification_number::InternationalSec
 }
 
 //let entity: Entity = fs.into(); // 或者 let entity = Entity::from(fs);
-impl From<tpex::net_asset_value_per_share::Emerging> for StockDbRow {
-    fn from(tpex: tpex::net_asset_value_per_share::Emerging) -> Self {
-        StockDbRow {
-            stock_symbol: tpex.stock_symbol,
-            name: "".to_string(),
-            suspend_listing: false,
-            net_asset_value_per_share: tpex.net_asset_value_per_share,
-            weight: Default::default(),
-            return_on_equity: Default::default(),
-            create_time: Local::now(),
-            stock_exchange_market_id: Default::default(),
-            stock_industry_id: Default::default(),
-            issued_share: 0,
-            qfii_shares_held: 0,
-            qfii_share_holding_percentage: Default::default(),
-        }
-    }
-}
 
 /// 取得未下市上市櫃每股淨值為零的股票
 pub async fn fetch_net_asset_value_per_share_is_zero() -> Result<Vec<StockDbRow>> {
@@ -521,21 +503,6 @@ mod tests {
         assert_eq!(stock.net_asset_value_per_share, Decimal::ZERO);
         assert_eq!(stock.weight, Decimal::ZERO);
         assert_eq!(stock.issued_share, 0);
-    }
-
-    #[test]
-    fn stock_from_emerging_maps_nav_and_symbol() {
-        let emerging =
-            tpex::net_asset_value_per_share::Emerging::new("6987".to_string(), dec!(42.19));
-
-        let stock = StockDbRow::from(emerging);
-
-        assert_eq!(stock.stock_symbol, "6987");
-        assert_eq!(stock.name, "");
-        assert_eq!(stock.net_asset_value_per_share, dec!(42.19));
-        assert_eq!(stock.stock_exchange_market_id, 0);
-        assert_eq!(stock.stock_industry_id, 0);
-        assert!(!stock.suspend_listing);
     }
 
     // 此測試驗證防禦性 upsert 邏輯（當新傳入的市場或產業編號為 0 時，保留資料庫中原先正確的非零值）。

--- a/src/interfaces/rpc/client/stock_service/mod.rs
+++ b/src/interfaces/rpc/client/stock_service/mod.rs
@@ -44,6 +44,23 @@ pub async fn push_stock_info_to_go_service(
     get_client().await?.update_stock_info(request).await
 }
 
+impl From<&crate::domain::registry::entity::Stock> for StockInfoRequest {
+    fn from(stock: &crate::domain::registry::entity::Stock) -> Self {
+        StockInfoRequest {
+            stock_symbol: stock.symbol().0.clone(),
+            name: stock.name().to_string(),
+            stock_exchange_market_id: stock.market_id(),
+            stock_industry_id: stock.industry_id(),
+            net_asset_value_per_share:
+                <rust_decimal::Decimal as rust_decimal::prelude::ToPrimitive>::to_f64(
+                    &stock.net_asset_value_per_share(),
+                )
+                .unwrap_or(0.0),
+            suspend_listing: stock.suspend_listing(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{core::logging, infra::cache::SHARE};
@@ -80,22 +97,5 @@ mod tests {
             }
         }
         logging::debug_file_async("結束 push_stock_info_to_go_service".to_string());
-    }
-}
-
-impl From<&crate::domain::registry::entity::Stock> for StockInfoRequest {
-    fn from(stock: &crate::domain::registry::entity::Stock) -> Self {
-        StockInfoRequest {
-            stock_symbol: stock.symbol().0.clone(),
-            name: stock.name().to_string(),
-            stock_exchange_market_id: stock.market_id(),
-            stock_industry_id: stock.industry_id(),
-            net_asset_value_per_share:
-                <rust_decimal::Decimal as rust_decimal::prelude::ToPrimitive>::to_f64(
-                    &stock.net_asset_value_per_share(),
-                )
-                .unwrap_or(0.0),
-            suspend_listing: stock.suspend_listing(),
-        }
     }
 }


### PR DESCRIPTION
Consolidates ACL usage, replaces redundant conversions, and renames stateless mapper associated functions from \	o_*\ to \rom_*\ to resolve all \clippy::wrong_self_convention\ warnings. Also resolves pre-existing clippy warnings.