### PR TITLE
Skip calculations on non-trading days to prevent invalid data insertion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/build.bat
+++ b/build.bat
@@ -8,7 +8,7 @@ set BIN_NAME=stock_crawler
 set BUILD_COUNT=0
 set TOTAL_ELAPSED_CS=0
 
-echo [1/8] Checking Zig...
+echo [1/9] Checking Zig...
 zig version >nul 2>&1
 if errorlevel 1 (
   echo Zig is not installed or not in PATH.
@@ -16,7 +16,7 @@ if errorlevel 1 (
   exit /b 1
 )
 
-echo [2/8] Checking CMake...
+echo [2/9] Checking CMake...
 cmake --version >nul 2>&1
 if errorlevel 1 (
   echo CMake is not installed or not in PATH.
@@ -26,7 +26,7 @@ if errorlevel 1 (
 
 
 
-echo [3/8] Updating Rust toolchain...
+echo [3/9] Updating Rust toolchain...
 rustup --version >nul 2>&1
 if errorlevel 1 (
   echo rustup is not installed or not in PATH.
@@ -39,7 +39,7 @@ if errorlevel 1 (
   exit /b 1
 )
 
-echo [4/8] Tool versions:
+echo [4/9] Tool versions:
 for /f "delims=" %%i in ('cmake --version ^| findstr /B /C:"cmake version"') do echo   - %%i
 for /f "delims=" %%i in ('zig version') do echo   - zig %%i
 for /f "delims=" %%i in ('cargo --version') do echo   - %%i
@@ -57,7 +57,7 @@ if errorlevel 1 (
   for /f "delims=" %%i in ('rustup --version 2^>nul') do echo   - %%i
 )
 
-echo [5/8] Ensuring Rust targets...
+echo [5/9] Ensuring Rust targets...
 for %%T in (%TARGETS%) do (
   echo   - Adding target %%T
   rustup target add %%T
@@ -67,7 +67,7 @@ for %%T in (%TARGETS%) do (
   )
 )
 
-echo [6/8] Checking cargo-zigbuild...
+echo [6/9] Checking cargo-zigbuild...
 cargo zigbuild -h >nul 2>&1
 if errorlevel 1 (
   echo cargo-zigbuild not found, installing...
@@ -78,7 +78,7 @@ if errorlevel 1 (
   )
 )
 
-echo [7/8] Building %BIN_NAME%...
+echo [7/9] Building %BIN_NAME% for cross targets...
 for %%T in (%TARGETS%) do (
   set /a BUILD_COUNT+=1
   echo.
@@ -112,9 +112,35 @@ for %%T in (%TARGETS%) do (
   echo Elapsed for %%T: !BUILD_ELAPSED_TEXT!
 )
 
+echo.
+echo [8/9] Building %BIN_NAME% for native Windows...
+call :GetTimeCentis WIN_BUILD_START_CS
+cargo build --%PROFILE%
+if errorlevel 1 (
+  echo Build failed for native Windows target.
+  exit /b 1
+)
+
+call :GetTimeCentis WIN_BUILD_END_CS
+set /a WIN_BUILD_ELAPSED_CS=!WIN_BUILD_END_CS! - !WIN_BUILD_START_CS!
+if !WIN_BUILD_ELAPSED_CS! lss 0 set /a WIN_BUILD_ELAPSED_CS+=8640000
+set /a TOTAL_ELAPSED_CS+=WIN_BUILD_ELAPSED_CS
+set /a BUILD_COUNT+=1
+
+set WIN_OUT_PATH=target\%PROFILE%\%BIN_NAME%.exe
+if exist "!WIN_OUT_PATH!" (
+  echo Output binary: !WIN_OUT_PATH!
+) else (
+  echo Build command finished, but binary not found at: !WIN_OUT_PATH!
+  exit /b 1
+)
+
+call :FormatElapsed !WIN_BUILD_ELAPSED_CS! WIN_BUILD_ELAPSED_TEXT
+echo Elapsed for native Windows: !WIN_BUILD_ELAPSED_TEXT!
+
 call :FormatElapsed %TOTAL_ELAPSED_CS% TOTAL_ELAPSED_TEXT
 echo.
-echo [8/8] Done.
+echo [9/9] Done.
 echo Targets built: %BUILD_COUNT%
 echo Total build time: %TOTAL_ELAPSED_TEXT%
 

--- a/build.ps1
+++ b/build.ps1
@@ -39,14 +39,14 @@ function Test-CommandExists {
     $null -ne (Get-Command $CommandName -ErrorAction SilentlyContinue)
 }
 
-Write-Host '[1/8] Checking Zig...'
+Write-Host '[1/9] Checking Zig...'
 if (-not (Test-CommandExists 'zig')) {
     Write-Host 'Zig is not installed or not in PATH.'
     Write-Host 'Please install Zig first: https://ziglang.org/download/'
     exit 1
 }
 
-Write-Host '[2/8] Checking CMake...'
+Write-Host '[2/9] Checking CMake...'
 if (-not (Test-CommandExists 'cmake')) {
     Write-Host 'CMake is not installed or not in PATH.'
     Write-Host 'Please install CMake first: https://cmake.org/download/'
@@ -55,7 +55,7 @@ if (-not (Test-CommandExists 'cmake')) {
 
 
 
-Write-Host '[3/8] Updating Rust toolchain...'
+Write-Host '[3/9] Updating Rust toolchain...'
 if (-not (Test-CommandExists 'rustup')) {
     Write-Host 'rustup is not installed or not in PATH.'
     Write-Host 'Please install rustup first: https://rustup.rs/'
@@ -67,7 +67,7 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
-Write-Host '[4/8] Tool versions:'
+Write-Host '[4/9] Tool versions:'
 Get-CommandOutput 'cmake' @('--version') |
     Where-Object { $_ -like 'cmake version*' } |
     ForEach-Object { Write-Host "  - $_" }
@@ -90,7 +90,7 @@ if (Test-CommandExists 'rustup') {
     Write-Host '  - rustup not found'
 }
 
-Write-Host '[5/8] Ensuring Rust targets...'
+Write-Host '[5/9] Ensuring Rust targets...'
 foreach ($target in $Targets) {
     Write-Host "  - Adding target $target"
     & rustup target add $target
@@ -100,7 +100,7 @@ foreach ($target in $Targets) {
     }
 }
 
-Write-Host '[6/8] Checking cargo-zigbuild...'
+Write-Host '[6/9] Checking cargo-zigbuild...'
 & cargo zigbuild -h *> $null
 if ($LASTEXITCODE -ne 0) {
     Write-Host 'cargo-zigbuild not found, installing...'
@@ -111,7 +111,7 @@ if ($LASTEXITCODE -ne 0) {
     }
 }
 
-Write-Host "[7/8] Building $BinName..."
+Write-Host "[7/9] Building $BinName for cross targets..."
 foreach ($target in $Targets) {
     $BuildCount += 1
     Write-Host ''
@@ -144,6 +144,27 @@ foreach ($target in $Targets) {
 }
 
 Write-Host ''
-Write-Host '[8/8] Done.'
+Write-Host "[8/9] Building $BinName for native Windows..."
+$winStart = Get-Date
+& cargo build "--$BuildProfile"
+if ($LASTEXITCODE -ne 0) {
+    Write-Host 'Build failed for native Windows target.'
+    exit 1
+}
+$winElapsed = (Get-Date) - $winStart
+$TotalElapsed = $TotalElapsed.Add($winElapsed)
+$BuildCount += 1
+
+$winOutPath = Join-Path 'target' "$BuildProfile\$BinName.exe"
+if (Test-Path -LiteralPath $winOutPath) {
+    Write-Host "Output binary: $winOutPath"
+} else {
+    Write-Host "Build command finished, but binary not found at: $winOutPath"
+    exit 1
+}
+Write-Host "Elapsed for native Windows: $(Format-Elapsed -Elapsed $winElapsed)"
+
+Write-Host ''
+Write-Host '[9/9] Done.'
 Write-Host "Targets built: $BuildCount"
 Write-Host "Total build time: $(Format-Elapsed -Elapsed $TotalElapsed)"

--- a/src/app/event/taiwan_stock/closing.rs
+++ b/src/app/event/taiwan_stock/closing.rs
@@ -52,41 +52,38 @@ pub(crate) async fn aggregate(date: NaiveDate) -> Result<()> {
     let daily_quote_count = backfill::quote::execute(date).await?;
     tracing::info!("抓取上市櫃收盤數據結束:{}", daily_quote_count);
 
-    if daily_quote_count > 0 {
-        // 有行情資料才執行的計算（均線、估價、殖利率排行）
-        let quote_repo = PgQuoteRepository::new();
-
-        let lack_daily_quotes_count = quote_repo.makeup_for_the_lack_daily_quotes(date).await?;
-        tracing::info!(
-            "補上當日缺少的每日收盤數據結束:{:#?}",
-            lack_daily_quotes_count
-        );
-
-        calculation::daily_quotes::calculate_moving_average(date).await?;
-        tracing::info!("計算均線結束");
-
-        quote_repo.rebuild_last_daily_quotes().await?;
-        tracing::info!("重建 last_daily_quotes 表內的數據結束");
-
-        calculation::estimated_price::calculate_estimated_price(date).await?;
-        tracing::info!("計算便宜、合理、昂貴價的估算結束");
-
-        let yield_rank_repo = PgYieldRankRepository::new();
-        use crate::domain::yield_rank::repository::YieldRankRepository;
-        yield_rank_repo.rebuild_by_date(date).await?;
-        tracing::info!("重建 yield_rank 表內的數據結束");
-    } else {
-        // 非交易日（假日/收盤 0 筆）：略過行情相關計算，
-        // 但仍繼續計算帳戶市值以保持 daily_money_history_detail 與
-        // last-closing-day 的一致性（SQL 使用視窗函數，會自動取最近
-        // 一個有效交易日的收盤價，非交易日執行結果仍正確）
-        tracing::info!("日期 {} 無交易資料，略過行情相關計算", date);
+    if daily_quote_count == 0 {
+        // 非交易日（假日/收盤 0 筆）：完全略過本次收盤匯總，包含帳戶市值計算，
+        // 避免 daily_money_history 系列表被寫入非交易日（如週末）的無效紀錄
+        // （部分表格的 upsert SQL 以「當日收盤價精確比對」為前提，非交易日
+        // 沒有對應收盤價時會產生全 0 的錯誤資料列）
+        tracing::info!("日期 {} 無交易資料，略過本次收盤匯總", date);
+        return Ok(());
     }
 
-    // 無論是否有新行情，都更新帳戶市值：
-    // - 交易日：使用當日收盤價計算
-    // - 非交易日：使用最近一個有效交易日的收盤價計算
-    // 確保 last-closing-day 若因任何原因被更新，daily_money_history_detail 都有對應資料
+    // 有行情資料才執行的計算（均線、估價、殖利率排行）
+    let quote_repo = PgQuoteRepository::new();
+
+    let lack_daily_quotes_count = quote_repo.makeup_for_the_lack_daily_quotes(date).await?;
+    tracing::info!(
+        "補上當日缺少的每日收盤數據結束:{:#?}",
+        lack_daily_quotes_count
+    );
+
+    calculation::daily_quotes::calculate_moving_average(date).await?;
+    tracing::info!("計算均線結束");
+
+    quote_repo.rebuild_last_daily_quotes().await?;
+    tracing::info!("重建 last_daily_quotes 表內的數據結束");
+
+    calculation::estimated_price::calculate_estimated_price(date).await?;
+    tracing::info!("計算便宜、合理、昂貴價的估算結束");
+
+    let yield_rank_repo = PgYieldRankRepository::new();
+    use crate::domain::yield_rank::repository::YieldRankRepository;
+    yield_rank_repo.rebuild_by_date(date).await?;
+    tracing::info!("重建 yield_rank 表內的數據結束");
+
     calculation::money_history::calculate_money_history(date).await?;
     tracing::info!("計算帳戶內市值結束");
 

--- a/src/infra/crawler/yahoo/mod.rs
+++ b/src/infra/crawler/yahoo/mod.rs
@@ -151,8 +151,9 @@ pub const LISTED_CLASS_CATEGORIES: &[YahooClassCategory] = &[
     YahooClassCategory::enabled(YahooClassExchange::Listed, 47, "其他電子"),
     YahooClassCategory::enabled(YahooClassExchange::Listed, 48, "ETN"),
     YahooClassCategory::disabled(YahooClassExchange::Listed, 49, "創新板"), // 因 Yahoo API 一直回空資料，故不採集
-    YahooClassCategory::enabled(YahooClassExchange::Listed, 51, "市牛證"),
-    YahooClassCategory::enabled(YahooClassExchange::Listed, 52, "市熊證"),
+    // 牛熊證常無成交量，採集到的價格恆為 0，會被 is_valid_price 過濾並噴出大量「過濾異常價格」雜訊，故不納入盤中採集。
+    YahooClassCategory::disabled(YahooClassExchange::Listed, 51, "市牛證"),
+    YahooClassCategory::disabled(YahooClassExchange::Listed, 52, "市熊證"),
     YahooClassCategory::enabled(YahooClassExchange::Listed, 93, "綠能環保"),
     YahooClassCategory::enabled(YahooClassExchange::Listed, 94, "數位雲端"),
     YahooClassCategory::enabled(YahooClassExchange::Listed, 95, "運動休閒"),
@@ -290,6 +291,8 @@ mod tests {
         let listed_call = find_category(YahooClassExchange::Listed, 31).unwrap();
         let listed_put = find_category(YahooClassExchange::Listed, 32).unwrap();
         let listed_index = find_category(YahooClassExchange::Listed, 33).unwrap();
+        let listed_bull = find_category(YahooClassExchange::Listed, 51).unwrap();
+        let listed_bear = find_category(YahooClassExchange::Listed, 52).unwrap();
         let otc_call = find_category(YahooClassExchange::OverTheCounter, 165).unwrap();
         let otc_put = find_category(YahooClassExchange::OverTheCounter, 166).unwrap();
         let otc_index = find_category(YahooClassExchange::OverTheCounter, 33).unwrap();
@@ -298,6 +301,8 @@ mod tests {
         assert!(!listed_call.collect_enabled);
         assert!(!listed_put.collect_enabled);
         assert!(!listed_index.collect_enabled);
+        assert!(!listed_bull.collect_enabled);
+        assert!(!listed_bear.collect_enabled);
         assert!(!otc_call.collect_enabled);
         assert!(!otc_put.collect_enabled);
         assert!(!otc_index.collect_enabled);

--- a/src/infra/crawler/yahoo/price/class_quote.rs
+++ b/src/infra/crawler/yahoo/price/class_quote.rs
@@ -683,17 +683,17 @@ mod tests {
         assert_eq!(category_key(&category), "TWO:153");
     }
 
-    /// 驗證盤中輪詢清單會排除認購 / 認售 / 指數類 / 公司債 / 牛證等不需採集的分類，
+    /// 驗證盤中輪詢清單會排除認購 / 認售 / 指數類 / 公司債 / 牛熊證等不需採集的分類，
     /// 只保留實際需要採集的分類。
     #[test]
     fn test_all_class_categories_excludes_disabled_categories() {
         let categories = all_class_categories();
 
-        assert_eq!(categories.len(), 95);
+        assert_eq!(categories.len(), 93);
         assert!(!categories.iter().any(|category| {
             matches!(
                 (category.exchange, category.sector_id),
-                (YahooClassExchange::Listed, 31..=33 | 49) // 排除指數類與回空資料的創新板(49)
+                (YahooClassExchange::Listed, 31..=33 | 49 | 51 | 52) // 排除指數類、回空資料的創新板(49)、牛熊證(51/52)
                     | (YahooClassExchange::OverTheCounter, 33 | 163 | 165..=167) // 公司債(163)、認購/認售(165/166)、牛證(167)
             )
         }));

--- a/src/interfaces/bot/telegram.rs
+++ b/src/interfaces/bot/telegram.rs
@@ -337,10 +337,7 @@ mod tests {
         for chunk in &chunks {
             assert!(chunk.chars().count() <= limit);
         }
-        assert_eq!(
-            chunks.iter().map(|c| c.chars().count()).sum::<usize>(),
-            250
-        );
+        assert_eq!(chunks.iter().map(|c| c.chars().count()).sum::<usize>(), 250);
     }
 
     /// 驗證 MarkdownV2 跳脫規則。

--- a/src/interfaces/bot/telegram.rs
+++ b/src/interfaces/bot/telegram.rs
@@ -159,7 +159,58 @@ fn get_client() -> &'static Telegram {
     TELEGRAM.get_or_init(Telegram::new)
 }
 
+/// Telegram `sendMessage` 的文字長度上限（entities 解析後的字元數）。
+///
+/// 官方限制為 4096；這裡預留一點餘裕，避免邊界情況下的計數誤差。
+const MAX_MESSAGE_LEN: usize = 4000;
+
+/// 依行為單位切割訊息，確保每個分段都不超過 Telegram 的長度限制。
+///
+/// 以整行為切割單位，避免把 MarkdownV2 的連結或跳脫序列從中間截斷。
+/// 若單行本身就超過上限（極端情況），才退回逐字切割，避免無窮迴圈或直接送不出去。
+fn split_message_into_chunks(msg: &str, limit: usize) -> Vec<String> {
+    if msg.chars().count() <= limit {
+        return vec![msg.to_string()];
+    }
+
+    let mut chunks = Vec::new();
+    let mut current = String::new();
+
+    for line in msg.split_inclusive('\n') {
+        if line.chars().count() > limit {
+            if !current.is_empty() {
+                chunks.push(std::mem::take(&mut current));
+            }
+            let mut slice = String::new();
+            for ch in line.chars() {
+                if slice.chars().count() >= limit {
+                    chunks.push(std::mem::take(&mut slice));
+                }
+                slice.push(ch);
+            }
+            if !slice.is_empty() {
+                chunks.push(slice);
+            }
+            continue;
+        }
+
+        if !current.is_empty() && current.chars().count() + line.chars().count() > limit {
+            chunks.push(std::mem::take(&mut current));
+        }
+        current.push_str(line);
+    }
+
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+
+    chunks
+}
+
 /// 異步發送 Telegram 消息
+///
+/// 若訊息長度超過 Telegram 的 4096 字元上限，會依行切割成多則訊息依序發送，
+/// 避免整則訊息因為過長而被 Bot API 以 400 Bad Request 拒絕。
 ///
 /// # Arguments
 ///
@@ -168,6 +219,14 @@ pub async fn send(msg: &str) {
     if msg.trim().is_empty() {
         return;
     }
+
+    for chunk in split_message_into_chunks(msg, MAX_MESSAGE_LEN) {
+        send_single(&chunk).await;
+    }
+}
+
+/// 發送單一則（已確保長度合法的）Telegram 消息。
+async fn send_single(msg: &str) {
     let client = get_client();
     match client.send(msg).await {
         Ok(rep) => {
@@ -234,6 +293,54 @@ mod tests {
 
         tracing::debug!("結束 test_send_message");
         time::sleep(Duration::from_secs(1)).await;
+    }
+
+    /// 驗證訊息未超過上限時不會被切割。
+    #[test]
+    fn test_split_message_into_chunks_keeps_short_message_intact() {
+        let msg = "line1\nline2\nline3\n";
+        let chunks = split_message_into_chunks(msg, 4000);
+        assert_eq!(chunks, vec![msg.to_string()]);
+    }
+
+    /// 驗證超過上限的訊息會依整行切割成多段，且每段都不超過上限。
+    #[test]
+    fn test_split_message_into_chunks_splits_by_line_when_too_long() {
+        let line = "x".repeat(30);
+        let msg = std::iter::repeat_n(line.clone(), 10)
+            .collect::<Vec<_>>()
+            .join("\n");
+        let limit = 100;
+
+        let chunks = split_message_into_chunks(&msg, limit);
+
+        assert!(chunks.len() > 1);
+        for chunk in &chunks {
+            assert!(chunk.chars().count() <= limit);
+        }
+        // 每一行內容都完整保留在切割後的某個分段中，沒有被腰斬。
+        assert_eq!(
+            chunks.iter().flat_map(|c| c.lines()).count(),
+            msg.lines().count()
+        );
+    }
+
+    /// 驗證單一行本身就超過上限的極端情況，會退回逐字切割而不是卡死或整段丟棄。
+    #[test]
+    fn test_split_message_into_chunks_falls_back_to_char_split_for_oversized_line() {
+        let msg = "a".repeat(250);
+        let limit = 100;
+
+        let chunks = split_message_into_chunks(&msg, limit);
+
+        assert_eq!(chunks.len(), 3);
+        for chunk in &chunks {
+            assert!(chunk.chars().count() <= limit);
+        }
+        assert_eq!(
+            chunks.iter().map(|c| c.chars().count()).sum::<usize>(),
+            250
+        );
     }
 
     /// 驗證 MarkdownV2 跳脫規則。

--- a/src/interfaces/web/backfill_admin/dto.rs
+++ b/src/interfaces/web/backfill_admin/dto.rs
@@ -282,7 +282,11 @@ pub(super) const INDEX_HTML: &str = r##"<!doctype html>
         event.preventDefault();
         const button = form.querySelector("button");
         const toast = form.querySelector(".toast");
-        const data = Object.fromEntries(new FormData(form).entries());
+        const data = {};
+        for (const [key, value] of new FormData(form).entries()) {
+          const field = form.elements.namedItem(key);
+          data[key] = field && field.type === "number" ? Number(value) : value;
+        }
         button.disabled = true;
         toast.textContent = "Starting...";
 


### PR DESCRIPTION
### Description

This pull request addresses the issue of unnecessary calculations on non-trading days where no data is available, such as weekends and holidays. The changes include:

- Introducing a conditional return to skip execution of closing summary logic on non-trading days.
- Enhancing tracing logs for clarity on skipped operations.
- Refining logic to ensure calculations (e.g., moving averages, valuation estimates, yield rankings) only trigger on trading days.

### Checklist

- [ ] Tests added/updated for new functionality.
- [ ] Documentation updated, if required.
- [ ] Code changes reviewed and approved.
- [ ] Verified that changes do not negatively impact existing functionality.