### PR TITLE
Add(cagr): 每日各期間年化報酬率排程、資料表與 Data API

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -215,6 +215,7 @@ jobs:
         psql -h localhost -U user -d db -a -f etc/sql/quote_history_record.sql
         psql -h localhost -U user -d db -a -f etc/sql/revenue.sql
         psql -h localhost -U user -d db -a -f etc/sql/revenue_last_date.sql
+        psql -h localhost -U user -d db -a -f etc/sql/stock_cagr.sql
         psql -h localhost -U user -d db -a -f etc/sql/stock_exchange_market.sql
         psql -h localhost -U user -d db -a -f etc/sql/stock_industry.sql
         psql -h localhost -U user -d db -a -f etc/sql/stock_ownership_details.sql
@@ -295,6 +296,7 @@ jobs:
         psql -h localhost -U user -d db -a -f etc/sql/quote_history_record.sql
         psql -h localhost -U user -d db -a -f etc/sql/revenue.sql
         psql -h localhost -U user -d db -a -f etc/sql/revenue_last_date.sql
+        psql -h localhost -U user -d db -a -f etc/sql/stock_cagr.sql
         psql -h localhost -U user -d db -a -f etc/sql/stock_exchange_market.sql
         psql -h localhost -U user -d db -a -f etc/sql/stock_industry.sql
         psql -h localhost -U user -d db -a -f etc/sql/stock_ownership_details.sql

--- a/control.sh
+++ b/control.sh
@@ -12,6 +12,8 @@ export script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export built_path="./target/release"
 export app_path="./bin"
 export binary_name="stock_crawler"
+# 開發機交叉編譯好的執行檔上傳到這裡（scp 到 /tmp），move 再從這裡搬到 script_dir。
+export upload_dir="${UPLOAD_BIN_DIR:-/tmp}"
 export pid_file="$script_dir/${app_path#./}/$binary_name.pid"
 export stdout_log="$script_dir/${app_path#./}/nohup.out"
 
@@ -96,15 +98,40 @@ function stop() {
   if kill -0 "$pid" 2>/dev/null; then
     kill -SIGTERM "$pid"
     log "已送出停止訊號給 pid $pid"
+    wait_for_exit "$pid"
   else
     log "pid $pid 已經不存在，可能是上次未正常關閉"
   fi
   rm -f "$pid_file"
 }
 
+# 等舊程序真的退出再返回。程式的 graceful shutdown 最久要等
+# gRPC 30s + Web 30s + 背景作業 5 分鐘（見 src/main.rs），
+# 這裡抓 6 分鐘上限，避免 update 在舊程序還活著時就把新的啟起來變成雙實例。
+function wait_for_exit() {
+  local pid="$1"
+  local waited=0
+  local limit="${STOP_WAIT_SECONDS:-360}"
+
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$waited" -ge "$limit" ]; then
+      log "pid $pid 已等待 ${limit}s 仍未結束，請確認後手動處理（kill -9 $pid）"
+      exit 1
+    fi
+    sleep 2
+    waited=$((waited + 2))
+    # 每 30 秒回報一次，讓長時間的背景作業收尾看得出還在進行中。
+    if [ $((waited % 30)) -eq 0 ]; then
+      log "等待 pid $pid 結束中... (${waited}s)"
+    fi
+  done
+
+  log "pid $pid 已結束（耗時 ${waited}s）"
+}
+
+# 執行檔改為在開發機交叉編譯後上傳，裝置端不再 cargo build，
+# 因此 update 只做「停止 → 就位 → 啟動」。
 function update() {
-  build
-  sleep 1
   stop
   sleep 1
   move
@@ -126,27 +153,40 @@ function build() {
 }
 
 function move() {
-  if [ -f "$built_path/$binary_name" ]; then
-    local binary_name_arch dest_path
-    binary_name_arch="$(resolve_binary_name)"
-    # 部署到跟 control.sh 同一層，跟 docker_build 及 start() 找執行檔的位置一致。
-    dest_path="$script_dir/$binary_name_arch"
+  local binary_name_arch dest_path src_path backup_name
+  binary_name_arch="$(resolve_binary_name)"
+  # 部署到跟 control.sh 同一層，跟 docker_build 及 start() 找執行檔的位置一致。
+  dest_path="$script_dir/$binary_name_arch"
 
-    backup_name="$binary_name_arch.$(date "+%Y%m%d-%H%M%S")"
-
-    # 如果舊檔案存在則備份
-    if [ -f "$dest_path" ]; then
-      mv "$dest_path" "$script_dir/$backup_name"
-      chmod -x "$script_dir/$backup_name"
-    fi
-
-    mv "$built_path/$binary_name" "$dest_path"
-    chmod +x "$dest_path"
-    log "檔案部署成功: $dest_path"
+  # 來源優先序：
+  #   1. UPLOAD_BIN_FILE 指定的完整路徑
+  #   2. 上傳目錄（預設 /tmp）底下的同名檔案 —— 開發機交叉編譯後 scp 到這裡；
+  #      不直接 scp 覆蓋執行中的檔案，否則會得到 "Text file busy"(ETXTBSY)
+  #   3. 本機 cargo build 的產物（保留給仍在裝置上編譯的情境）
+  if [ -n "$UPLOAD_BIN_FILE" ]; then
+    src_path="$UPLOAD_BIN_FILE"
+  elif [ -f "$upload_dir/$binary_name_arch" ]; then
+    src_path="$upload_dir/$binary_name_arch"
+  elif [ -f "$built_path/$binary_name" ]; then
+    src_path="$built_path/$binary_name"
   else
-    log "錯誤: 找不到編譯後的檔案 $built_path/$binary_name"
+    log "錯誤: 找不到可部署的執行檔"
+    log "請先將交叉編譯好的 $binary_name_arch 上傳到 $upload_dir/（或用 UPLOAD_BIN_FILE 指定路徑）"
     exit 1
   fi
+
+  backup_name="$binary_name_arch.$(date "+%Y%m%d-%H%M%S")"
+
+  # 如果舊檔案存在則備份。先把舊檔改名移走，新檔才是建立全新的 inode，
+  # 就算舊程序還沒完全結束也不會踩到 ETXTBSY。
+  if [ -f "$dest_path" ]; then
+    mv "$dest_path" "$script_dir/$backup_name"
+    chmod -x "$script_dir/$backup_name"
+  fi
+
+  mv "$src_path" "$dest_path"
+  chmod +x "$dest_path"
+  log "檔案部署成功: $dest_path（來源 $src_path）"
 }
 
 # --- Docker 相關指令 ---
@@ -232,9 +272,9 @@ function help() {
   echo "    start          - 啟動服務"
   echo "    stop           - 停止服務"
   echo "    restart        - 重啟服務"
-  echo "    build          - 編譯專案"
-  echo "    move           - 部署編譯後的檔案"
-  echo "    update         - 完整更新 (build + stop + move + start)"
+  echo "    build          - 編譯專案（裝置端自行編譯時才需要）"
+  echo "    move           - 將上傳的執行檔就位（來源：UPLOAD_BIN_FILE > $upload_dir/ > target/release）"
+  echo "    update         - 完整更新 (stop + move + start)"
   echo ""
   echo "  [Docker 模式]"
   echo "    docker_start   - 啟動容器"

--- a/etc/sql/stock_cagr.sql
+++ b/etc/sql/stock_cagr.sql
@@ -39,7 +39,7 @@ comment on table public.stock_cagr is '每日 CAGR：固定投入金額於各統
 
 comment on column public.stock_cagr.date is '計算基準日（期末交易日）';
 comment on column public.stock_cagr.stock_symbol is '股票代號';
-comment on column public.stock_cagr.period is '統計期間代碼：M3/M6/Y1/Y1H/Y2/Y3/Y5/Y10';
+comment on column public.stock_cagr.period is '統計期間代碼：M3/M6/Y1/Y1H/Y2/Y3/Y5/Y7/Y10';
 comment on column public.stock_cagr.base_date is '實際採用的期初交易日（名目期初日無報價時可順延，見 BASE_DATE_GRACE_DAYS）';
 comment on column public.stock_cagr.base_price is '期初收盤價';
 comment on column public.stock_cagr.end_price is '期末收盤價';

--- a/etc/sql/stock_cagr.sql
+++ b/etc/sql/stock_cagr.sql
@@ -1,0 +1,94 @@
+create table if not exists public.stock_cagr
+(
+    date              date                     default CURRENT_DATE          not null,
+    stock_symbol      varchar(24)              default ''::character varying not null,
+    period            varchar(8)               default ''::character varying not null,
+    base_date         date,
+    base_price        numeric(18, 4),
+    end_price         numeric(18, 4),
+    years             numeric(10, 6),
+    -- 口徑 A：純價格
+    price_end_shares  numeric(28, 8),
+    price_end_value   numeric(18, 4),
+    price_return_pct  numeric(18, 4),
+    price_cagr_pct    numeric(18, 4),
+    -- 口徑 B：含息不再投入（主指標）
+    total_shares      numeric(28, 8),
+    total_cash        numeric(18, 4),
+    total_end_value   numeric(18, 4),
+    total_return_pct  numeric(18, 4),
+    total_cagr_pct    numeric(18, 4),
+    -- 口徑 C：含息再投入
+    reinv_shares      numeric(28, 8),
+    reinv_cash        numeric(18, 4),
+    reinv_end_value   numeric(18, 4),
+    reinv_return_pct  numeric(18, 4),
+    reinv_cagr_pct    numeric(18, 4),
+    -- 品質旗標
+    first_quote_date  date,
+    shortfall_days    integer,
+    data_complete     boolean                  default false                 not null,
+    has_anomaly       boolean                  default false                 not null,
+    dividend_events   integer                  default 0                     not null,
+    created_time      timestamp with time zone default now()                 not null,
+    updated_time      timestamp with time zone default now()                 not null,
+    primary key (date, stock_symbol, period)
+);
+
+comment on table public.stock_cagr is '每日 CAGR：固定投入金額於各統計期間、各報酬口徑的模擬結果';
+
+comment on column public.stock_cagr.date is '計算基準日（期末交易日）';
+comment on column public.stock_cagr.stock_symbol is '股票代號';
+comment on column public.stock_cagr.period is '統計期間代碼：M3/M6/Y1/Y1H/Y2/Y3/Y5/Y10';
+comment on column public.stock_cagr.base_date is '實際採用的期初交易日（名目期初日無報價時可順延，見 BASE_DATE_GRACE_DAYS）';
+comment on column public.stock_cagr.base_price is '期初收盤價';
+comment on column public.stock_cagr.end_price is '期末收盤價';
+comment on column public.stock_cagr.years is '實際年數 =（期末交易日 − 期初交易日）/ 365';
+
+comment on column public.stock_cagr.price_end_shares is '口徑 A（純價格）：期末持有股數';
+comment on column public.stock_cagr.price_end_value is '口徑 A（純價格）：期末總價值（元）';
+comment on column public.stock_cagr.price_return_pct is '口徑 A（純價格）：區間總報酬率（%）';
+comment on column public.stock_cagr.price_cagr_pct is '口徑 A（純價格）：年化報酬率（%）';
+
+comment on column public.stock_cagr.total_shares is '口徑 B（含息不再投入）：期末持有股數（含配股）';
+comment on column public.stock_cagr.total_cash is '口徑 B（含息不再投入）：累積現金股利（元）';
+comment on column public.stock_cagr.total_end_value is '口徑 B（含息不再投入）：期末總價值（元）';
+comment on column public.stock_cagr.total_return_pct is '口徑 B（含息不再投入）：區間總報酬率（%）';
+comment on column public.stock_cagr.total_cagr_pct is '口徑 B（含息不再投入）：年化報酬率（%），為主指標';
+
+comment on column public.stock_cagr.reinv_shares is '口徑 C（含息再投入）：期末持有股數（含配股與現金股利買回）';
+comment on column public.stock_cagr.reinv_cash is '口徑 C（含息再投入）：未能買回的剩餘現金（元），通常為零';
+comment on column public.stock_cagr.reinv_end_value is '口徑 C（含息再投入）：期末總價值（元）';
+comment on column public.stock_cagr.reinv_return_pct is '口徑 C（含息再投入）：區間總報酬率（%）';
+comment on column public.stock_cagr.reinv_cagr_pct is '口徑 C（含息再投入）：年化報酬率（%）';
+
+comment on column public.stock_cagr.first_quote_date is '該股在 DailyQuotes 的最早報價日，用於判定新上市／資料未涵蓋';
+comment on column public.stock_cagr.shortfall_days is 'base_date 較名目期初目標日晚幾天；0 表完全對齊';
+comment on column public.stock_cagr.data_complete is '期初資料是否齊全；false 時所有數值欄位皆為 NULL（絕不以 0 代替）';
+comment on column public.stock_cagr.has_anomaly is '期間內是否偵測到無對應除權息的價格跳動（疑似減資或分割）';
+comment on column public.stock_cagr.dividend_events is '期間內實際採計的除權息次數';
+
+-- 排行榜索引（每個口徑各一條）。
+-- 查詢型態固定為「指定 date + period，依某口徑年化報酬率由高至低取前 N 筆」，
+-- 因此以 (date desc, period, <口徑>_cagr_pct desc) 排列即可直接依序掃描；
+-- INCLUDE 讓排行榜常用的代號與區間總報酬免於回表。
+-- partial 條件 data_complete = true 與查詢條件一致，可大幅縮小索引體積
+-- （長期間如 Y10 約有四成列為資料不足）。
+create index if not exists "stock_cagr-rank-total-idx"
+    on public.stock_cagr (date desc, period, total_cagr_pct desc)
+    include (stock_symbol, total_return_pct)
+    where data_complete = true;
+
+create index if not exists "stock_cagr-rank-price-idx"
+    on public.stock_cagr (date desc, period, price_cagr_pct desc)
+    include (stock_symbol, price_return_pct)
+    where data_complete = true;
+
+create index if not exists "stock_cagr-rank-reinv-idx"
+    on public.stock_cagr (date desc, period, reinv_cagr_pct desc)
+    include (stock_symbol, reinv_return_pct)
+    where data_complete = true;
+
+-- 個股歷史索引：查詢單一個股某期間的時間序列（含資料不足者），故不加 partial 條件。
+create index if not exists "stock_cagr-symbol-period-date-idx"
+    on public.stock_cagr (stock_symbol, period, date desc);

--- a/src/app/calculation/cagr.rs
+++ b/src/app/calculation/cagr.rs
@@ -1,0 +1,408 @@
+use std::collections::{HashMap, HashSet};
+
+use anyhow::{Context, Result};
+use chrono::{Months, NaiveDate};
+use rust_decimal::Decimal;
+
+use crate::domain::performance::{
+    CagrPeriod, CagrRepository, CagrSourceRepository, DividendEvent, StockCagr,
+    entity::{BASE_DATE_GRACE_DAYS, PRINCIPAL},
+    simulator::{SimulationInput, simulate},
+};
+
+/// 單次批次寫入的列數上限。
+///
+/// 全市場約 2,600 檔 × 8 個期間 ≈ 20,700 列，分批送避免單一 statement 過大。
+const SAVE_CHUNK_SIZE: usize = 2_000;
+
+/// 每日 CAGR 計算的執行摘要。
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CagrCalculationSummary {
+    /// 計算基準日（期末交易日）。
+    pub date: Option<NaiveDate>,
+    /// 母體檔數。
+    pub universe: usize,
+    /// 實際計算的期間數（扣除因資料不足而整個跳過者）。
+    pub periods_calculated: usize,
+    /// 因資料庫歷史深度不足而整個跳過的期間數。
+    pub periods_skipped: usize,
+    /// 寫入的資料列數。
+    pub rows_written: u64,
+    /// 標記為疑似異常的股票檔數。
+    pub anomaly_symbols: usize,
+}
+
+/// 排程進入點：以資料庫中最新交易日為基準計算全市場 CAGR。
+///
+/// 刻意排在每日 05:40（台北時間）—— 也就是 21:00 的年度配息回補與 05:00–05:30
+/// 各項回補之後。CAGR 完全依賴股利資料，若在收盤鏈（15:00）就算完，當晚回補
+/// 進來的股利不會反映到當日結果。
+pub async fn execute_scheduled() -> Result<()> {
+    let summary = execute(None).await?;
+    match summary.date {
+        Some(date) => tracing::info!(
+            date = %date,
+            universe = summary.universe,
+            periods_calculated = summary.periods_calculated,
+            periods_skipped = summary.periods_skipped,
+            rows_written = summary.rows_written,
+            anomaly_symbols = summary.anomaly_symbols,
+            "每日 CAGR 計算完成"
+        ),
+        None => tracing::warn!("每日 CAGR 計算未產生任何結果（無可用交易日或母體為空）"),
+    }
+    Ok(())
+}
+
+/// 計算並寫入指定基準日的全市場 CAGR。
+///
+/// 傳入 `None` 時自動採用資料庫中最新的交易日。
+pub async fn execute(date: Option<NaiveDate>) -> Result<CagrCalculationSummary> {
+    let source = crate::infra::database::repository::cagr_source::PgCagrSourceRepository::new();
+    let repository = crate::infra::database::repository::performance::PgCagrRepository::new();
+    calculate(&source, &repository, date).await
+}
+
+/// 實際的計算流程。
+///
+/// 以 trait 物件而非具體型別接收相依，讓流程本身可以在測試中注入假資料源驗證，
+/// 不需要真實資料庫。
+pub async fn calculate(
+    source: &dyn CagrSourceRepository,
+    repository: &dyn CagrRepository,
+    date: Option<NaiveDate>,
+) -> Result<CagrCalculationSummary> {
+    let mut summary = CagrCalculationSummary::default();
+
+    // ── 1. 決定期末交易日 ────────────────────────────────────────────
+    let end_date = match date {
+        Some(d) => source
+            .fetch_trading_day_on_or_before(d)
+            .await
+            .context("Failed to align end date to a trading day")?,
+        None => source
+            .fetch_latest_trading_day()
+            .await
+            .context("Failed to fetch the latest trading day")?,
+    };
+    let Some(end_date) = end_date else {
+        tracing::warn!("報價資料中找不到任何交易日，略過本次 CAGR 計算");
+        return Ok(summary);
+    };
+    summary.date = Some(end_date);
+
+    // ── 2. 母體與期末價格 ────────────────────────────────────────────
+    let symbols = source
+        .fetch_active_symbols()
+        .await
+        .context("Failed to fetch active symbols")?;
+    summary.universe = symbols.len();
+    if symbols.is_empty() {
+        tracing::warn!("計算母體為空，略過本次 CAGR 計算");
+        return Ok(summary);
+    }
+
+    let end_prices: HashMap<String, Decimal> = source
+        .fetch_closing_prices_on(end_date)
+        .await
+        .context("Failed to fetch closing prices on the end date")?
+        .into_iter()
+        .collect();
+
+    let first_quote_dates: HashMap<String, NaiveDate> = source
+        .fetch_first_quote_dates()
+        .await
+        .context("Failed to fetch first quote dates")?
+        .into_iter()
+        .collect();
+
+    // ── 3. 逐期間對齊期初交易日 ──────────────────────────────────────
+    //
+    // 採「全市場統一對齊」：先算出整個市場共同的期初交易日，個股當天沒有報價
+    // 時才套用寬限規則。若改成每檔各自往前找，長期停牌的股票會取到很久以前的
+    // 價格，「期間」名不符實，也無法橫向比較。
+    let mut aligned: Vec<(CagrPeriod, NaiveDate, NaiveDate)> = Vec::new();
+    for period in CagrPeriod::ALL {
+        let Some(target) = end_date.checked_sub_months(Months::new(period.months())) else {
+            continue;
+        };
+        match source
+            .fetch_trading_day_on_or_before(target)
+            .await
+            .with_context(|| format!("Failed to align base date for period {}", period.code()))?
+        {
+            Some(base_date) => aligned.push((period, target, base_date)),
+            None => {
+                // 資料庫的歷史深度不足以涵蓋此期間，整個期間跳過而非寫入
+                // 兩萬多列全 NULL 的資料。
+                tracing::warn!(
+                    period = period.code(),
+                    target = %target,
+                    "報價歷史不足以涵蓋此期間，整個跳過"
+                );
+                summary.periods_skipped += 1;
+            }
+        }
+    }
+    if aligned.is_empty() {
+        tracing::warn!("沒有任何期間的期初交易日可對齊，略過本次 CAGR 計算");
+        return Ok(summary);
+    }
+    summary.periods_calculated = aligned.len();
+
+    // 最長期間的期初日，用於一次撈齊股利事件與異常偵測範圍。
+    let earliest_base_date = aligned
+        .iter()
+        .map(|(_, _, base_date)| *base_date)
+        .min()
+        .unwrap_or(end_date);
+
+    // ── 4. 股利事件（一次撈齊最長期間，於記憶體分派到各期間）──────────
+    //
+    // 八個期間中最長者涵蓋其餘所有期間，只掃一次即可；對 dividend 表掃八輪
+    // 是不必要的浪費。
+    let events = source
+        .fetch_dividend_events_since(earliest_base_date)
+        .await
+        .context("Failed to fetch dividend events")?;
+    let events_by_symbol = group_events_by_symbol(events);
+
+    // ── 5. 再投入口徑所需的除息日價格（批次，不逐筆查詢）──────────────
+    let reinvest_pairs = collect_reinvest_pairs(&events_by_symbol, earliest_base_date, end_date);
+    let reinvest_prices = source
+        .fetch_closing_prices_at(&reinvest_pairs)
+        .await
+        .context("Failed to fetch closing prices for reinvestment")?;
+    let reinvest_prices = group_prices_by_symbol(reinvest_prices);
+
+    // ── 6. 異常偵測（疑似減資／分割）────────────────────────────────
+    //
+    // 只查一次最長期間的事件，再依日期切分到各期間。若改成「用最長期間算一次
+    // 代號清單、套用到所有期間」，2017 年的減資會把 3 個月期間的結果也標記為
+    // 異常 —— 那個旗標的意思是「這個期間內發生過未建模的公司行動」，跨期間共用
+    // 語義就錯了。
+    let anomaly_events = source
+        .fetch_anomaly_events(earliest_base_date, end_date)
+        .await
+        .context("Failed to detect anomaly events")?;
+    summary.anomaly_symbols = anomaly_events
+        .iter()
+        .map(|(symbol, _)| symbol.as_str())
+        .collect::<HashSet<_>>()
+        .len();
+
+    // ── 7. 逐期間計算 ───────────────────────────────────────────────
+    let empty_events: Vec<DividendEvent> = Vec::new();
+    let empty_prices: HashMap<NaiveDate, Decimal> = HashMap::new();
+
+    for (period, target, base_date) in aligned {
+        // 只採計落在本期間 (base_date, end_date] 內的異常事件。
+        let period_anomalies: HashSet<&str> = anomaly_events
+            .iter()
+            .filter(|(_, event_date)| *event_date > base_date && *event_date <= end_date)
+            .map(|(symbol, _)| symbol.as_str())
+            .collect();
+
+        let base_prices: HashMap<String, Decimal> = source
+            .fetch_closing_prices_on(base_date)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to fetch closing prices for period {}",
+                    period.code()
+                )
+            })?
+            .into_iter()
+            .collect();
+
+        // 寬限查詢：期初交易日當天沒有報價的股票，往後找寬限期內的第一筆。
+        // 這讓「期初日剛好停牌三天的老股票」仍能計算，同時把「上個月才上市的
+        // 新股」明確擋在門檻外 —— 兩者的資訊價值天差地遠，不該同等對待。
+        let grace_deadline = base_date
+            .checked_add_signed(chrono::Duration::days(BASE_DATE_GRACE_DAYS))
+            .unwrap_or(base_date);
+        let grace_quotes: HashMap<String, (NaiveDate, Decimal)> = source
+            .fetch_first_quote_within(base_date, grace_deadline)
+            .await
+            .with_context(|| format!("Failed to fetch grace-period quotes for {}", period.code()))?
+            .into_iter()
+            .map(|(symbol, quote_date, price)| (symbol, (quote_date, price)))
+            .collect();
+
+        let mut records = Vec::with_capacity(symbols.len());
+        for symbol in &symbols {
+            let events = events_by_symbol.get(symbol).unwrap_or(&empty_events);
+            let prices = reinvest_prices.get(symbol).unwrap_or(&empty_prices);
+            records.push(build_record(
+                symbol,
+                period,
+                end_date,
+                target,
+                base_date,
+                base_prices.get(symbol).copied(),
+                grace_quotes.get(symbol).copied(),
+                end_prices.get(symbol).copied(),
+                first_quote_dates.get(symbol).copied(),
+                events,
+                prices,
+                period_anomalies.contains(symbol.as_str()),
+            ));
+        }
+
+        for chunk in records.chunks(SAVE_CHUNK_SIZE) {
+            summary.rows_written += repository
+                .save_batch(chunk)
+                .await
+                .with_context(|| format!("Failed to save CAGR batch for {}", period.code()))?;
+        }
+
+        tracing::info!(
+            period = period.code(),
+            base_date = %base_date,
+            rows = records.len(),
+            "CAGR 期間計算完成"
+        );
+    }
+
+    Ok(summary)
+}
+
+/// 組出單一股票在單一期間的計算結果。
+///
+/// 資料不足時回傳的 `StockCagr` 各數值欄位為 `None`，`data_complete` 為
+/// `false` —— 刻意不寫 0，否則「上市半年的新股」會在十年排行榜上被誤讀成
+/// 「十年零報酬」。這類列仍然寫入資料庫，讓「某檔在某期間的狀態」永遠查得到，
+/// API 才能穩定回傳、前端也不必區分「查無資料」與「不可計算」兩套邏輯。
+#[allow(clippy::too_many_arguments)]
+fn build_record(
+    symbol: &str,
+    period: CagrPeriod,
+    end_date: NaiveDate,
+    target: NaiveDate,
+    aligned_base_date: NaiveDate,
+    base_price_on_aligned: Option<Decimal>,
+    grace_quote: Option<(NaiveDate, Decimal)>,
+    end_price: Option<Decimal>,
+    first_quote_date: Option<NaiveDate>,
+    events: &[DividendEvent],
+    reinvest_prices: &HashMap<NaiveDate, Decimal>,
+    has_anomaly: bool,
+) -> StockCagr {
+    let incomplete = |base_date: Option<NaiveDate>, base_price: Option<Decimal>| StockCagr {
+        date: end_date,
+        stock_symbol: symbol.to_string(),
+        period,
+        base_date,
+        base_price,
+        end_price,
+        years: None,
+        price: None,
+        total: None,
+        reinvested: None,
+        first_quote_date,
+        shortfall_days: None,
+        data_complete: false,
+        has_anomaly,
+        dividend_events: 0,
+    };
+
+    // 期初價：優先用統一對齊日當天的報價；當天沒有才套用寬限規則。
+    let (base_date, base_price) = match base_price_on_aligned {
+        Some(price) => (aligned_base_date, price),
+        None => match grace_quote {
+            Some((quote_date, price)) => (quote_date, price),
+            None => return incomplete(None, None),
+        },
+    };
+
+    let Some(end_price) = end_price else {
+        // 期末無報價（停牌中或當日未交易），無法結算。
+        return incomplete(Some(base_date), Some(base_price));
+    };
+
+    let lookup = |date: NaiveDate| reinvest_prices.get(&date).copied();
+    let input = SimulationInput {
+        principal: Decimal::from(PRINCIPAL),
+        base_date,
+        end_date,
+        base_price,
+        end_price,
+        events,
+        reinvest_prices: &lookup,
+    };
+
+    let Some(result) = simulate(&input) else {
+        return incomplete(Some(base_date), Some(base_price));
+    };
+
+    StockCagr {
+        date: end_date,
+        stock_symbol: symbol.to_string(),
+        period,
+        base_date: Some(base_date),
+        base_price: Some(base_price),
+        end_price: Some(end_price),
+        years: Some(result.years),
+        // 近十年每年皆有 134–216 檔股票配股，期間愈長，忽略配股造成的低估
+        // 愈嚴重，故長期間不提供純價格口徑。
+        price: period.supports_price_metric().then_some(result.price),
+        total: Some(result.total),
+        reinvested: Some(result.reinvested),
+        first_quote_date,
+        shortfall_days: Some((base_date - target).num_days().max(0) as i32),
+        data_complete: true,
+        has_anomaly,
+        dividend_events: result.dividend_events,
+    }
+}
+
+/// 將股利事件依股票代號分組。
+fn group_events_by_symbol(events: Vec<DividendEvent>) -> HashMap<String, Vec<DividendEvent>> {
+    let mut grouped: HashMap<String, Vec<DividendEvent>> = HashMap::new();
+    for event in events {
+        grouped
+            .entry(event.stock_symbol.clone())
+            .or_default()
+            .push(event);
+    }
+    grouped
+}
+
+/// 收集「含息再投入」口徑需要查價的 (股票代號, 除息日) 組合。
+///
+/// 只收集區間內、且確實有現金股利的事件 —— 配股不需要查價，區間外的事件
+/// 也不會生效。這讓查詢量從「所有股票 × 所有交易日」縮到實際需要的數萬筆。
+fn collect_reinvest_pairs(
+    events_by_symbol: &HashMap<String, Vec<DividendEvent>>,
+    from: NaiveDate,
+    to: NaiveDate,
+) -> Vec<(String, NaiveDate)> {
+    let mut pairs = Vec::new();
+    let mut seen: HashSet<(String, NaiveDate)> = HashSet::new();
+    for events in events_by_symbol.values() {
+        for event in events {
+            let Some(date) = event.ex_dividend_date_cash else {
+                continue;
+            };
+            if event.cash_dividend <= Decimal::ZERO || date <= from || date > to {
+                continue;
+            }
+            let key = (event.stock_symbol.clone(), date);
+            if seen.insert(key.clone()) {
+                pairs.push(key);
+            }
+        }
+    }
+    pairs
+}
+
+/// 將 (代號, 日期, 價格) 攤平結果整理成以代號為索引的查價表。
+fn group_prices_by_symbol(
+    prices: Vec<(String, NaiveDate, Decimal)>,
+) -> HashMap<String, HashMap<NaiveDate, Decimal>> {
+    let mut grouped: HashMap<String, HashMap<NaiveDate, Decimal>> = HashMap::new();
+    for (symbol, date, price) in prices {
+        grouped.entry(symbol).or_default().insert(date, price);
+    }
+    grouped
+}

--- a/src/app/calculation/cagr.rs
+++ b/src/app/calculation/cagr.rs
@@ -406,3 +406,591 @@ fn group_prices_by_symbol(
     }
     grouped
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::domain::performance::entity::{CagrCoverage, CagrMetric};
+    use crate::domain::performance::query::{CagrRankingPage, CagrRankingQuery};
+
+    fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).expect("測試日期應合法")
+    }
+
+    fn dec(value: i64) -> Decimal {
+        Decimal::from(value)
+    }
+
+    /// 以記憶體資料模擬 [`CagrSourceRepository`]，讓整段編排流程不需資料庫即可驗證。
+    #[derive(Default)]
+    struct FakeSource {
+        /// 全市場交易日，須由早至晚排序。
+        trading_days: Vec<NaiveDate>,
+        symbols: Vec<String>,
+        /// 每檔股票的收盤價序列。
+        prices: HashMap<String, BTreeMap<NaiveDate, Decimal>>,
+        events: Vec<DividendEvent>,
+        anomalies: Vec<(String, NaiveDate)>,
+        /// 各方法的呼叫次數，用來驗證「一次撈齊」而非 N+1 的設計。
+        calls: Mutex<HashMap<&'static str, usize>>,
+    }
+
+    impl FakeSource {
+        fn record(&self, name: &'static str) {
+            *self
+                .calls
+                .lock()
+                .expect("測試鎖不應中毒")
+                .entry(name)
+                .or_insert(0) += 1;
+        }
+
+        fn call_count(&self, name: &str) -> usize {
+            self.calls
+                .lock()
+                .expect("測試鎖不應中毒")
+                .get(name)
+                .copied()
+                .unwrap_or(0)
+        }
+    }
+
+    #[async_trait]
+    impl CagrSourceRepository for FakeSource {
+        async fn fetch_trading_day_on_or_before(
+            &self,
+            date: NaiveDate,
+        ) -> Result<Option<NaiveDate>> {
+            self.record("fetch_trading_day_on_or_before");
+            Ok(self
+                .trading_days
+                .iter()
+                .filter(|day| **day <= date)
+                .max()
+                .copied())
+        }
+
+        async fn fetch_latest_trading_day(&self) -> Result<Option<NaiveDate>> {
+            self.record("fetch_latest_trading_day");
+            Ok(self.trading_days.iter().max().copied())
+        }
+
+        async fn fetch_active_symbols(&self) -> Result<Vec<String>> {
+            self.record("fetch_active_symbols");
+            Ok(self.symbols.clone())
+        }
+
+        async fn fetch_first_quote_dates(&self) -> Result<Vec<(String, NaiveDate)>> {
+            self.record("fetch_first_quote_dates");
+            Ok(self
+                .prices
+                .iter()
+                .filter_map(|(symbol, series)| {
+                    series.keys().next().map(|first| (symbol.clone(), *first))
+                })
+                .collect())
+        }
+
+        async fn fetch_closing_prices_on(&self, date: NaiveDate) -> Result<Vec<(String, Decimal)>> {
+            self.record("fetch_closing_prices_on");
+            Ok(self
+                .prices
+                .iter()
+                .filter_map(|(symbol, series)| {
+                    series.get(&date).map(|price| (symbol.clone(), *price))
+                })
+                .collect())
+        }
+
+        async fn fetch_first_quote_within(
+            &self,
+            from: NaiveDate,
+            to: NaiveDate,
+        ) -> Result<Vec<(String, NaiveDate, Decimal)>> {
+            self.record("fetch_first_quote_within");
+            Ok(self
+                .prices
+                .iter()
+                .filter_map(|(symbol, series)| {
+                    series
+                        .range(from..=to)
+                        .next()
+                        .map(|(quote_date, price)| (symbol.clone(), *quote_date, *price))
+                })
+                .collect())
+        }
+
+        async fn fetch_dividend_events_since(
+            &self,
+            since: NaiveDate,
+        ) -> Result<Vec<DividendEvent>> {
+            self.record("fetch_dividend_events_since");
+            Ok(self
+                .events
+                .iter()
+                .filter(|event| event.sort_key().is_some_and(|day| day >= since))
+                .cloned()
+                .collect())
+        }
+
+        async fn fetch_closing_prices_at(
+            &self,
+            pairs: &[(String, NaiveDate)],
+        ) -> Result<Vec<(String, NaiveDate, Decimal)>> {
+            self.record("fetch_closing_prices_at");
+            Ok(pairs
+                .iter()
+                .filter_map(|(symbol, day)| {
+                    self.prices
+                        .get(symbol)
+                        .and_then(|series| series.get(day))
+                        .map(|price| (symbol.clone(), *day, *price))
+                })
+                .collect())
+        }
+
+        async fn fetch_anomaly_events(
+            &self,
+            from: NaiveDate,
+            to: NaiveDate,
+        ) -> Result<Vec<(String, NaiveDate)>> {
+            self.record("fetch_anomaly_events");
+            Ok(self
+                .anomalies
+                .iter()
+                .filter(|(_, day)| *day > from && *day <= to)
+                .cloned()
+                .collect())
+        }
+    }
+
+    /// 只記錄寫入內容的 [`CagrRepository`]；讀取類方法在本測試不會被呼叫。
+    #[derive(Default)]
+    struct RecordingRepository {
+        saved: Mutex<Vec<StockCagr>>,
+        save_calls: Mutex<usize>,
+    }
+
+    impl RecordingRepository {
+        fn record_of(&self, symbol: &str, period: CagrPeriod) -> StockCagr {
+            self.saved
+                .lock()
+                .expect("測試鎖不應中毒")
+                .iter()
+                .find(|row| row.stock_symbol == symbol && row.period == period)
+                .cloned()
+                .unwrap_or_else(|| panic!("找不到 {symbol} 的 {} 結果", period.code()))
+        }
+
+        fn saved_len(&self) -> usize {
+            self.saved.lock().expect("測試鎖不應中毒").len()
+        }
+    }
+
+    #[async_trait]
+    impl CagrRepository for RecordingRepository {
+        async fn save_batch(&self, records: &[StockCagr]) -> Result<u64> {
+            *self.save_calls.lock().expect("測試鎖不應中毒") += 1;
+            self.saved
+                .lock()
+                .expect("測試鎖不應中毒")
+                .extend_from_slice(records);
+            Ok(records.len() as u64)
+        }
+
+        async fn fetch_ranking(
+            &self,
+            _date: NaiveDate,
+            _period: CagrPeriod,
+            _metric: CagrMetric,
+            _limit: i64,
+            _offset: i64,
+        ) -> Result<Vec<StockCagr>> {
+            unimplemented!("計算流程不會讀取排行榜")
+        }
+
+        async fn fetch_ranking_page(&self, _query: &CagrRankingQuery) -> Result<CagrRankingPage> {
+            unimplemented!("計算流程不會讀取排行榜")
+        }
+
+        async fn fetch_by_symbol(
+            &self,
+            _date: NaiveDate,
+            _stock_symbol: &str,
+        ) -> Result<Vec<StockCagr>> {
+            unimplemented!("計算流程不會讀取個股結果")
+        }
+
+        async fn fetch_coverage(
+            &self,
+            _date: NaiveDate,
+            _period: CagrPeriod,
+            _metric: CagrMetric,
+        ) -> Result<CagrCoverage> {
+            unimplemented!("計算流程不會讀取涵蓋統計")
+        }
+
+        async fn fetch_latest_date(&self) -> Result<Option<NaiveDate>> {
+            unimplemented!("計算流程不會讀取最新基準日")
+        }
+
+        async fn delete_before(&self, _date: NaiveDate) -> Result<u64> {
+            unimplemented!("計算流程不做保留期清理")
+        }
+    }
+
+    /// 建立 2015-01 起每月 1 日的交易日，最後補上期末日 2026-08-03。
+    fn monthly_trading_days() -> Vec<NaiveDate> {
+        let mut days = Vec::new();
+        for year in 2015..=2026 {
+            for month in 1..=12 {
+                let day = date(year, month, 1);
+                if day <= date(2026, 8, 1) {
+                    days.push(day);
+                }
+            }
+        }
+        days.push(date(2026, 5, 15));
+        days.push(date(2026, 8, 3));
+        days.sort_unstable();
+        days
+    }
+
+    /// 三檔股票，各自對應一種待驗證情境：
+    ///
+    /// - `2330`：全期間都有報價，價格逐月上升，且有除權息與一次疑似減資
+    /// - `1101`：期初日當天無報價，但落在 30 天寬限期內（走寬限分支）
+    /// - `9999`：有期初價但期末日停牌（走「期末無報價」分支）
+    fn fixture_source() -> FakeSource {
+        let trading_days = monthly_trading_days();
+
+        let mut prices: HashMap<String, BTreeMap<NaiveDate, Decimal>> = HashMap::new();
+        let series_2330: BTreeMap<NaiveDate, Decimal> = trading_days
+            .iter()
+            .enumerate()
+            .map(|(index, day)| (*day, dec(50 + index as i64)))
+            .collect();
+        prices.insert("2330".to_string(), series_2330);
+
+        // 除息日不是月初，另外補進價格序列供再投入口徑查價。
+        prices
+            .get_mut("2330")
+            .expect("2330 序列應存在")
+            .insert(date(2024, 6, 20), dec(120));
+
+        prices.insert(
+            "1101".to_string(),
+            trading_days
+                .iter()
+                .filter(|day| **day >= date(2026, 5, 15))
+                .map(|day| (*day, dec(30)))
+                .collect(),
+        );
+
+        prices.insert(
+            "9999".to_string(),
+            trading_days
+                .iter()
+                .filter(|day| **day < date(2026, 8, 3))
+                .map(|day| (*day, dec(20)))
+                .collect(),
+        );
+
+        FakeSource {
+            trading_days,
+            symbols: vec!["2330".to_string(), "1101".to_string(), "9999".to_string()],
+            prices,
+            events: vec![
+                DividendEvent {
+                    stock_symbol: "2330".to_string(),
+                    ex_dividend_date_cash: Some(date(2024, 6, 20)),
+                    ex_dividend_date_stock: None,
+                    cash_dividend: dec(5),
+                    stock_dividend: Decimal::ZERO,
+                },
+                DividendEvent {
+                    stock_symbol: "2330".to_string(),
+                    ex_dividend_date_stock: Some(date(2019, 7, 1)),
+                    ex_dividend_date_cash: None,
+                    cash_dividend: Decimal::ZERO,
+                    stock_dividend: dec(1),
+                },
+            ],
+            anomalies: vec![("2330".to_string(), date(2019, 3, 1))],
+            calls: Mutex::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn calculate_writes_one_row_per_symbol_and_period() {
+        let source = fixture_source();
+        let repository = RecordingRepository::default();
+
+        let summary = calculate(&source, &repository, None)
+            .await
+            .expect("計算不應失敗");
+
+        assert_eq!(summary.date, Some(date(2026, 8, 3)));
+        assert_eq!(summary.universe, 3);
+        assert_eq!(summary.periods_calculated, CagrPeriod::ALL.len());
+        assert_eq!(summary.periods_skipped, 0);
+        // 母體中每一檔在每個期間都必須有一列，否則涵蓋率會被高估。
+        assert_eq!(summary.rows_written, 24);
+        assert_eq!(repository.saved_len(), 24);
+        assert_eq!(summary.anomaly_symbols, 1);
+    }
+
+    #[tokio::test]
+    async fn calculate_fetches_dividend_events_only_once_for_all_periods() {
+        let source = fixture_source();
+        let repository = RecordingRepository::default();
+
+        calculate(&source, &repository, None)
+            .await
+            .expect("計算不應失敗");
+
+        // 八個期間共用同一次股利查詢與同一次異常偵測。
+        assert_eq!(source.call_count("fetch_dividend_events_since"), 1);
+        assert_eq!(source.call_count("fetch_anomaly_events"), 1);
+        assert_eq!(source.call_count("fetch_closing_prices_at"), 1);
+    }
+
+    #[tokio::test]
+    async fn complete_record_carries_all_three_metrics_on_short_periods() {
+        let source = fixture_source();
+        let repository = RecordingRepository::default();
+        calculate(&source, &repository, None)
+            .await
+            .expect("計算不應失敗");
+
+        let record = repository.record_of("2330", CagrPeriod::M3);
+        assert!(record.data_complete);
+        assert_eq!(record.base_date, Some(date(2026, 5, 1)));
+        assert_eq!(record.shortfall_days, Some(0));
+        assert!(record.price.is_some(), "M3 應提供純價格口徑");
+        assert!(record.total.is_some());
+        assert!(record.reinvested.is_some());
+        // 2019 年的疑似減資不落在三個月內，不得標記。
+        assert!(!record.has_anomaly);
+    }
+
+    #[tokio::test]
+    async fn long_periods_drop_price_metric_but_keep_the_others() {
+        let source = fixture_source();
+        let repository = RecordingRepository::default();
+        calculate(&source, &repository, None)
+            .await
+            .expect("計算不應失敗");
+
+        let record = repository.record_of("2330", CagrPeriod::Y10);
+        assert!(record.data_complete);
+        assert!(
+            record.price.is_none(),
+            "長期間配股普遍，純價格口徑會系統性低估，不得提供"
+        );
+        assert!(record.total.is_some());
+        assert!(record.reinvested.is_some());
+        // 期間內的兩次除權息都要採計。
+        assert_eq!(record.dividend_events, 2);
+        assert!(record.has_anomaly, "2019 年的疑似減資落在十年期間內");
+    }
+
+    #[tokio::test]
+    async fn grace_period_quote_is_used_when_the_aligned_base_date_has_no_price() {
+        let source = fixture_source();
+        let repository = RecordingRepository::default();
+        calculate(&source, &repository, None)
+            .await
+            .expect("計算不應失敗");
+
+        let record = repository.record_of("1101", CagrPeriod::M3);
+        assert!(record.data_complete);
+        assert_eq!(record.base_date, Some(date(2026, 5, 15)));
+        // 名目目標日為 2026-05-03，實際採用 05-15，落後 12 天。
+        assert_eq!(record.shortfall_days, Some(12));
+    }
+
+    #[tokio::test]
+    async fn insufficient_history_is_written_as_null_row_not_zero() {
+        let source = fixture_source();
+        let repository = RecordingRepository::default();
+        calculate(&source, &repository, None)
+            .await
+            .expect("計算不應失敗");
+
+        let record = repository.record_of("1101", CagrPeriod::Y10);
+        assert!(!record.data_complete);
+        assert_eq!(record.base_date, None);
+        assert_eq!(record.base_price, None);
+        // 絕不以 0 代替，否則新股會被誤讀成「十年零報酬」。
+        assert_eq!(record.years, None);
+        assert_eq!(record.total, None);
+        assert_eq!(record.reinvested, None);
+        assert_eq!(record.dividend_events, 0);
+        assert_eq!(record.first_quote_date, Some(date(2026, 5, 15)));
+    }
+
+    #[tokio::test]
+    async fn missing_end_price_keeps_base_data_but_marks_incomplete() {
+        let source = fixture_source();
+        let repository = RecordingRepository::default();
+        calculate(&source, &repository, None)
+            .await
+            .expect("計算不應失敗");
+
+        let record = repository.record_of("9999", CagrPeriod::Y1);
+        assert!(!record.data_complete);
+        // 期末停牌無法結算，但期初資料仍應保留以利追查。
+        assert_eq!(record.base_date, Some(date(2025, 8, 1)));
+        assert_eq!(record.base_price, Some(dec(20)));
+        assert_eq!(record.end_price, None);
+        assert_eq!(record.total, None);
+    }
+
+    #[tokio::test]
+    async fn explicit_date_is_aligned_to_the_nearest_trading_day() {
+        let source = fixture_source();
+        let repository = RecordingRepository::default();
+
+        // 2026-08-05 不是交易日，應對齊到 08-03。
+        let summary = calculate(&source, &repository, Some(date(2026, 8, 5)))
+            .await
+            .expect("計算不應失敗");
+
+        assert_eq!(summary.date, Some(date(2026, 8, 3)));
+        assert_eq!(source.call_count("fetch_latest_trading_day"), 0);
+    }
+
+    #[tokio::test]
+    async fn periods_beyond_available_history_are_skipped_entirely() {
+        let mut source = fixture_source();
+        // 只保留最近四個月的交易日：僅 M3 有辦法對齊期初日。
+        source.trading_days.retain(|day| *day >= date(2026, 5, 1));
+        let repository = RecordingRepository::default();
+
+        let summary = calculate(&source, &repository, None)
+            .await
+            .expect("計算不應失敗");
+
+        assert_eq!(summary.periods_calculated, 1);
+        assert_eq!(summary.periods_skipped, 7);
+        // 跳過的期間不寫入任何列，避免灌進兩萬多列全 NULL 的資料。
+        assert_eq!(summary.rows_written, 3);
+    }
+
+    #[tokio::test]
+    async fn no_trading_day_returns_empty_summary_without_touching_the_repository() {
+        let source = FakeSource::default();
+        let repository = RecordingRepository::default();
+
+        let summary = calculate(&source, &repository, None)
+            .await
+            .expect("計算不應失敗");
+
+        assert_eq!(summary, CagrCalculationSummary::default());
+        assert_eq!(repository.saved_len(), 0);
+        assert_eq!(source.call_count("fetch_active_symbols"), 0);
+    }
+
+    #[tokio::test]
+    async fn empty_universe_stops_before_fetching_prices() {
+        let mut source = fixture_source();
+        source.symbols.clear();
+        let repository = RecordingRepository::default();
+
+        let summary = calculate(&source, &repository, None)
+            .await
+            .expect("計算不應失敗");
+
+        assert_eq!(summary.date, Some(date(2026, 8, 3)));
+        assert_eq!(summary.universe, 0);
+        assert_eq!(summary.rows_written, 0);
+        assert_eq!(source.call_count("fetch_closing_prices_on"), 0);
+    }
+
+    #[test]
+    fn collect_reinvest_pairs_keeps_only_in_range_cash_dividends() {
+        let from = date(2024, 1, 1);
+        let to = date(2024, 12, 31);
+        let event = |day: NaiveDate, cash: Decimal| DividendEvent {
+            stock_symbol: "2330".to_string(),
+            ex_dividend_date_cash: Some(day),
+            ex_dividend_date_stock: None,
+            cash_dividend: cash,
+            stock_dividend: Decimal::ZERO,
+        };
+
+        let mut events_by_symbol = HashMap::new();
+        events_by_symbol.insert(
+            "2330".to_string(),
+            vec![
+                event(date(2024, 6, 20), dec(5)),
+                // 同一天重複出現只需查一次價。
+                event(date(2024, 6, 20), dec(5)),
+                // 期初日當天不生效（區間為左開右閉）。
+                event(from, dec(5)),
+                // 期末之後不生效。
+                event(date(2025, 1, 2), dec(5)),
+                // 沒有現金股利的事件不需查價。
+                event(date(2024, 8, 15), Decimal::ZERO),
+                // 只有除權日的事件不需查價。
+                DividendEvent {
+                    stock_symbol: "2330".to_string(),
+                    ex_dividend_date_cash: None,
+                    ex_dividend_date_stock: Some(date(2024, 7, 1)),
+                    cash_dividend: Decimal::ZERO,
+                    stock_dividend: dec(1),
+                },
+            ],
+        );
+
+        let pairs = collect_reinvest_pairs(&events_by_symbol, from, to);
+
+        assert_eq!(pairs, vec![("2330".to_string(), date(2024, 6, 20))]);
+    }
+
+    #[test]
+    fn group_helpers_index_by_symbol() {
+        let events = vec![
+            DividendEvent {
+                stock_symbol: "2330".to_string(),
+                ex_dividend_date_cash: Some(date(2024, 6, 20)),
+                ex_dividend_date_stock: None,
+                cash_dividend: dec(5),
+                stock_dividend: Decimal::ZERO,
+            },
+            DividendEvent {
+                stock_symbol: "2330".to_string(),
+                ex_dividend_date_cash: Some(date(2023, 6, 20)),
+                ex_dividend_date_stock: None,
+                cash_dividend: dec(3),
+                stock_dividend: Decimal::ZERO,
+            },
+            DividendEvent {
+                stock_symbol: "1101".to_string(),
+                ex_dividend_date_cash: Some(date(2024, 7, 10)),
+                ex_dividend_date_stock: None,
+                cash_dividend: dec(1),
+                stock_dividend: Decimal::ZERO,
+            },
+        ];
+
+        let grouped = group_events_by_symbol(events);
+        assert_eq!(grouped["2330"].len(), 2);
+        assert_eq!(grouped["1101"].len(), 1);
+
+        let prices = group_prices_by_symbol(vec![
+            ("2330".to_string(), date(2024, 6, 20), dec(120)),
+            ("2330".to_string(), date(2023, 6, 20), dec(100)),
+            ("1101".to_string(), date(2024, 7, 10), dec(30)),
+        ]);
+        assert_eq!(prices["2330"].len(), 2);
+        assert_eq!(prices["2330"][&date(2024, 6, 20)], dec(120));
+        assert_eq!(prices["1101"].len(), 1);
+    }
+}

--- a/src/app/calculation/cagr.rs
+++ b/src/app/calculation/cagr.rs
@@ -63,7 +63,78 @@ pub async fn execute(date: Option<NaiveDate>) -> Result<CagrCalculationSummary> 
     calculate(&source, &repository, date).await
 }
 
-/// 實際的計算流程。
+/// 回填單一期間的執行摘要。
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CagrPeriodBackfillSummary {
+    /// 待回填的基準日數。
+    pub dates_pending: usize,
+    /// 實際完成計算的基準日數。
+    pub dates_processed: usize,
+    /// 因報價歷史深度不足而無法計算的基準日數。
+    pub dates_skipped: usize,
+    /// 寫入的資料列數。
+    pub rows_written: u64,
+}
+
+/// 為既有的歷史基準日回填單一統計期間。
+///
+/// 新增期間（例如 Y7）之後，既有基準日不會自動長出該期間的資料 —— 排程只算
+/// 當日。這個進入點掃出「已有其他期間結果、但缺少指定期間」的基準日，逐日
+/// 補算**該期間**而已；不重算已存在的期間，避免多花八倍的查詢。
+///
+/// 從未計算過的日期不在範圍內：那是歷史初始化，成本與語義都是另一回事。
+pub async fn backfill_period(period: CagrPeriod) -> Result<CagrPeriodBackfillSummary> {
+    let source = crate::infra::database::repository::cagr_source::PgCagrSourceRepository::new();
+    let repository = crate::infra::database::repository::performance::PgCagrRepository::new();
+    backfill_period_with(&source, &repository, period).await
+}
+
+/// [`backfill_period`] 的可注入版本，供測試驗證流程本身。
+pub async fn backfill_period_with(
+    source: &dyn CagrSourceRepository,
+    repository: &dyn CagrRepository,
+    period: CagrPeriod,
+) -> Result<CagrPeriodBackfillSummary> {
+    let dates = repository
+        .fetch_dates_missing_period(period)
+        .await
+        .with_context(|| format!("Failed to fetch dates missing period {}", period.code()))?;
+
+    let mut summary = CagrPeriodBackfillSummary {
+        dates_pending: dates.len(),
+        ..Default::default()
+    };
+    if dates.is_empty() {
+        tracing::info!(period = period.code(), "沒有需要回填的基準日");
+        return Ok(summary);
+    }
+
+    for date in dates {
+        let result = calculate_periods(source, repository, Some(date), &[period])
+            .await
+            .with_context(|| format!("Failed to backfill period {} on {date}", period.code()))?;
+
+        // 期初日落在報價涵蓋範圍之外時整個期間會被跳過，該基準日不產生任何列。
+        if result.periods_calculated == 0 {
+            summary.dates_skipped += 1;
+            continue;
+        }
+        summary.dates_processed += 1;
+        summary.rows_written += result.rows_written;
+    }
+
+    tracing::info!(
+        period = period.code(),
+        dates_pending = summary.dates_pending,
+        dates_processed = summary.dates_processed,
+        dates_skipped = summary.dates_skipped,
+        rows_written = summary.rows_written,
+        "期間回填完成"
+    );
+    Ok(summary)
+}
+
+/// 實際的計算流程（全部期間）。
 ///
 /// 以 trait 物件而非具體型別接收相依，讓流程本身可以在測試中注入假資料源驗證，
 /// 不需要真實資料庫。
@@ -71,6 +142,19 @@ pub async fn calculate(
     source: &dyn CagrSourceRepository,
     repository: &dyn CagrRepository,
     date: Option<NaiveDate>,
+) -> Result<CagrCalculationSummary> {
+    calculate_periods(source, repository, date, &CagrPeriod::ALL).await
+}
+
+/// 計算指定的期間子集。
+///
+/// 回填單一期間時只送一個期間進來，其餘流程（母體、股利事件、異常偵測）完全
+/// 共用 —— 那些查詢本來就與期間無關，逐期間重跑只是浪費。
+pub async fn calculate_periods(
+    source: &dyn CagrSourceRepository,
+    repository: &dyn CagrRepository,
+    date: Option<NaiveDate>,
+    periods: &[CagrPeriod],
 ) -> Result<CagrCalculationSummary> {
     let mut summary = CagrCalculationSummary::default();
 
@@ -122,7 +206,7 @@ pub async fn calculate(
     // 時才套用寬限規則。若改成每檔各自往前找，長期停牌的股票會取到很久以前的
     // 價格，「期間」名不符實，也無法橫向比較。
     let mut aligned: Vec<(CagrPeriod, NaiveDate, NaiveDate)> = Vec::new();
-    for period in CagrPeriod::ALL {
+    for period in periods.iter().copied() {
         let Some(target) = end_date.checked_sub_months(Months::new(period.months())) else {
             continue;
         };
@@ -574,6 +658,8 @@ mod tests {
     struct RecordingRepository {
         saved: Mutex<Vec<StockCagr>>,
         save_calls: Mutex<usize>,
+        /// `fetch_dates_missing_period` 要回傳的基準日。
+        missing_dates: Vec<NaiveDate>,
     }
 
     impl RecordingRepository {
@@ -589,6 +675,20 @@ mod tests {
 
         fn saved_len(&self) -> usize {
             self.saved.lock().expect("測試鎖不應中毒").len()
+        }
+
+        /// 已寫入資料列涵蓋的期間集合。
+        fn saved_periods(&self) -> Vec<CagrPeriod> {
+            let mut periods: Vec<CagrPeriod> = self
+                .saved
+                .lock()
+                .expect("測試鎖不應中毒")
+                .iter()
+                .map(|row| row.period)
+                .collect();
+            periods.sort_unstable();
+            periods.dedup();
+            periods
         }
     }
 
@@ -637,6 +737,10 @@ mod tests {
 
         async fn fetch_latest_date(&self) -> Result<Option<NaiveDate>> {
             unimplemented!("計算流程不會讀取最新基準日")
+        }
+
+        async fn fetch_dates_missing_period(&self, _period: CagrPeriod) -> Result<Vec<NaiveDate>> {
+            Ok(self.missing_dates.clone())
         }
 
         async fn delete_before(&self, _date: NaiveDate) -> Result<u64> {
@@ -911,6 +1015,82 @@ mod tests {
         assert_eq!(summary.universe, 0);
         assert_eq!(summary.rows_written, 0);
         assert_eq!(source.call_count("fetch_closing_prices_on"), 0);
+    }
+
+    #[tokio::test]
+    async fn backfill_period_only_calculates_the_requested_period() {
+        let source = fixture_source();
+        let repository = RecordingRepository {
+            missing_dates: vec![date(2026, 8, 3)],
+            ..Default::default()
+        };
+
+        let summary = backfill_period_with(&source, &repository, CagrPeriod::Y7)
+            .await
+            .expect("回填不應失敗");
+
+        assert_eq!(summary.dates_pending, 1);
+        assert_eq!(summary.dates_processed, 1);
+        assert_eq!(summary.dates_skipped, 0);
+        // 母體三檔 × 只有 Y7 一個期間。
+        assert_eq!(summary.rows_written, 3);
+        assert_eq!(
+            repository.saved_periods(),
+            vec![CagrPeriod::Y7],
+            "回填不得順便重算其他期間"
+        );
+    }
+
+    #[tokio::test]
+    async fn backfill_period_processes_every_pending_date() {
+        let source = fixture_source();
+        let repository = RecordingRepository {
+            missing_dates: vec![date(2026, 7, 1), date(2026, 8, 3)],
+            ..Default::default()
+        };
+
+        let summary = backfill_period_with(&source, &repository, CagrPeriod::Y1)
+            .await
+            .expect("回填不應失敗");
+
+        assert_eq!(summary.dates_pending, 2);
+        assert_eq!(summary.dates_processed, 2);
+        assert_eq!(summary.rows_written, 6);
+    }
+
+    #[tokio::test]
+    async fn backfill_period_counts_dates_without_enough_history_as_skipped() {
+        let mut source = fixture_source();
+        // 只留最近四個月的交易日：Y10 的期初日無從對齊。
+        source.trading_days.retain(|day| *day >= date(2026, 5, 1));
+        let repository = RecordingRepository {
+            missing_dates: vec![date(2026, 8, 3)],
+            ..Default::default()
+        };
+
+        let summary = backfill_period_with(&source, &repository, CagrPeriod::Y10)
+            .await
+            .expect("回填不應失敗");
+
+        assert_eq!(summary.dates_skipped, 1);
+        assert_eq!(summary.dates_processed, 0);
+        assert_eq!(summary.rows_written, 0);
+        assert_eq!(repository.saved_len(), 0);
+    }
+
+    #[tokio::test]
+    async fn backfill_period_is_a_no_op_when_nothing_is_missing() {
+        let source = fixture_source();
+        let repository = RecordingRepository::default();
+
+        let summary = backfill_period_with(&source, &repository, CagrPeriod::Y7)
+            .await
+            .expect("回填不應失敗");
+
+        assert_eq!(summary, CagrPeriodBackfillSummary::default());
+        // 沒有待回填的日期時，連交易日都不該去查。
+        assert_eq!(source.call_count("fetch_latest_trading_day"), 0);
+        assert_eq!(source.call_count("fetch_active_symbols"), 0);
     }
 
     #[test]

--- a/src/app/calculation/cagr.rs
+++ b/src/app/calculation/cagr.rs
@@ -740,8 +740,8 @@ mod tests {
         assert_eq!(summary.periods_calculated, CagrPeriod::ALL.len());
         assert_eq!(summary.periods_skipped, 0);
         // 母體中每一檔在每個期間都必須有一列，否則涵蓋率會被高估。
-        assert_eq!(summary.rows_written, 24);
-        assert_eq!(repository.saved_len(), 24);
+        assert_eq!(summary.rows_written, 27);
+        assert_eq!(repository.saved_len(), 27);
         assert_eq!(summary.anomaly_symbols, 1);
     }
 
@@ -878,7 +878,7 @@ mod tests {
             .expect("計算不應失敗");
 
         assert_eq!(summary.periods_calculated, 1);
-        assert_eq!(summary.periods_skipped, 7);
+        assert_eq!(summary.periods_skipped, CagrPeriod::ALL.len() - 1);
         // 跳過的期間不寫入任何列，避免灌進兩萬多列全 NULL 的資料。
         assert_eq!(summary.rows_written, 3);
     }

--- a/src/app/calculation/mod.rs
+++ b/src/app/calculation/mod.rs
@@ -1,3 +1,5 @@
+/// 固定投入 10,000 元的各期間年化報酬率（CAGR）
+pub mod cagr;
 /// 股票每日行情
 pub mod daily_quotes;
 /// 計算股票股息收入

--- a/src/app/manual_backfill.rs
+++ b/src/app/manual_backfill.rs
@@ -21,6 +21,8 @@
 //!   寫入 `dividend` 表、重算年度彙總列，並同步回補已領股利紀錄。
 //! - `test_backfill_cagr_for_date`：
 //!   依 [`MANUAL_CAGR_DATE`] 重算指定基準日的全市場各期間年化報酬率，寫入 `stock_cagr`。
+//! - `test_backfill_cagr_period`：
+//!   依 [`MANUAL_CAGR_PERIOD`] 為既有的歷史基準日回填單一統計期間（新增期間後專用）。
 
 use chrono::NaiveDate;
 
@@ -28,6 +30,7 @@ use crate::{
     app::backfill::{dividend, quote, taiwan_stock_index},
     app::calculation::{cagr, dividend_record},
     app::event::taiwan_stock::closing,
+    domain::performance::CagrPeriod,
     infra::cache::SHARE,
 };
 
@@ -47,6 +50,11 @@ const MANUAL_HISTORICAL_DIVIDEND_SECURITY_CODE: &str = "2887";
 ///
 /// 空字串表示改用資料庫中最新的交易日。
 const MANUAL_CAGR_DATE: &str = "";
+
+/// 手動回填單一統計期間時使用的期間代碼。
+///
+/// 新增期間後把這裡改成該期間的代碼再執行 `test_backfill_cagr_period`。
+const MANUAL_CAGR_PERIOD: &str = "Y7";
 
 /// 手動回補指定交易日的各股每日收盤報價。
 ///
@@ -240,5 +248,46 @@ async fn test_backfill_cagr_for_date() {
         summary.periods_skipped,
         summary.rows_written,
         summary.anomaly_symbols
+    );
+}
+
+/// 為既有的歷史基準日回填單一統計期間（[`MANUAL_CAGR_PERIOD`]）。
+///
+/// 新增期間之後專用：排程只算當日，既有基準日不會自動長出新期間的資料。
+/// 此入口掃出「已有其他期間結果、但缺少該期間」的基準日逐日補算，
+/// **只算指定期間**，不重算已存在的其他期間。
+///
+/// 從未計算過的日期不在範圍內；要初始化那些日期請改用
+/// [`test_backfill_cagr_for_date`] 逐日執行。
+///
+/// 全程只讀資料庫既有的報價與股利，不呼叫任何外部網站；重複執行為冪等。
+///
+/// 執行範例：
+/// `cargo test app::manual_backfill::test_backfill_cagr_period -- --ignored --nocapture`
+#[tokio::test]
+#[ignore]
+async fn test_backfill_cagr_period() {
+    dotenvy::dotenv().ok();
+    SHARE.load().await;
+
+    let period =
+        CagrPeriod::from_code(MANUAL_CAGR_PERIOD).expect("manual cagr period 應為合法代碼");
+
+    tracing::debug!(
+        "開始 app::manual_backfill::test_backfill_cagr_period period={}",
+        period.code()
+    );
+
+    let summary = cagr::backfill_period(period)
+        .await
+        .expect("manual cagr period backfill failed");
+
+    tracing::debug!(
+        "結束 app::manual_backfill::test_backfill_cagr_period period={} dates_pending={} dates_processed={} dates_skipped={} rows_written={}",
+        period.code(),
+        summary.dates_pending,
+        summary.dates_processed,
+        summary.dates_skipped,
+        summary.rows_written
     );
 }

--- a/src/app/manual_backfill.rs
+++ b/src/app/manual_backfill.rs
@@ -19,12 +19,14 @@
 //! - `test_backfill_historical_dividends_for_stock`：
 //!   依 [`MANUAL_HISTORICAL_DIVIDEND_SECURITY_CODE`] 從 Yahoo 回補單檔股票歷年股利，
 //!   寫入 `dividend` 表、重算年度彙總列，並同步回補已領股利紀錄。
+//! - `test_backfill_cagr_for_date`：
+//!   依 [`MANUAL_CAGR_DATE`] 重算指定基準日的全市場各期間年化報酬率，寫入 `stock_cagr`。
 
 use chrono::NaiveDate;
 
 use crate::{
     app::backfill::{dividend, quote, taiwan_stock_index},
-    app::calculation::dividend_record,
+    app::calculation::{cagr, dividend_record},
     app::event::taiwan_stock::closing,
     infra::cache::SHARE,
 };
@@ -40,6 +42,11 @@ const MANUAL_DIVIDEND_RECORD_SECURITY_CODE: &str = "0056";
 
 /// 手動回補單檔歷年股利時使用的預設股票代號。
 const MANUAL_HISTORICAL_DIVIDEND_SECURITY_CODE: &str = "2887";
+
+/// 手動重算各期間年化報酬率時使用的預設基準日。
+///
+/// 空字串表示改用資料庫中最新的交易日。
+const MANUAL_CAGR_DATE: &str = "";
 
 /// 手動回補指定交易日的各股每日收盤報價。
 ///
@@ -190,5 +197,48 @@ async fn test_backfill_historical_dividends_for_stock() {
 
     tracing::debug!(
         "結束 app::manual_backfill::test_backfill_historical_dividends_for_stock security_code={security_code} upserted_count={upserted_count}"
+    );
+}
+
+/// 手動重算指定基準日的全市場各期間年化報酬率（CAGR）。
+///
+/// 排程本身每日 05:40（台北時間）自動執行，這個入口用於：
+/// 股利資料事後回補後需要重算、或首次上線時補算某一天的結果。
+///
+/// 計算完全依賴資料庫既有的報價與股利，不會呼叫任何外部網站；
+/// 同一 `(基準日, 股票, 期間)` 重複執行為冪等的 upsert 覆蓋。
+///
+/// 執行範例：
+/// `cargo test app::manual_backfill::test_backfill_cagr_for_date -- --ignored --nocapture`
+#[tokio::test]
+#[ignore]
+async fn test_backfill_cagr_for_date() {
+    dotenvy::dotenv().ok();
+    SHARE.load().await;
+
+    // 空字串代表交由 use case 自行採用資料庫中最新的交易日。
+    let date = if MANUAL_CAGR_DATE.is_empty() {
+        None
+    } else {
+        Some(
+            NaiveDate::parse_from_str(MANUAL_CAGR_DATE, "%Y-%m-%d")
+                .expect("manual cagr date should be valid"),
+        )
+    };
+
+    tracing::debug!("開始 app::manual_backfill::test_backfill_cagr_for_date date={date:?}");
+
+    let summary = cagr::execute(date)
+        .await
+        .expect("manual cagr backfill failed");
+
+    tracing::debug!(
+        "結束 app::manual_backfill::test_backfill_cagr_for_date date={:?} universe={} periods_calculated={} periods_skipped={} rows_written={} anomaly_symbols={}",
+        summary.date,
+        summary.universe,
+        summary.periods_calculated,
+        summary.periods_skipped,
+        summary.rows_written,
+        summary.anomaly_symbols
     );
 }

--- a/src/app/scheduler.rs
+++ b/src/app/scheduler.rs
@@ -9,6 +9,7 @@ use crate::{
         delisted_company, dividend, etf, financial_statement, isin, net_asset_value_per_share,
         qualified_foreign_institutional_investor, revenue, stock_weight,
     },
+    app::calculation,
     app::event,
     // 通知一律走 core::alert 抽象介面（port）：app 層不 import
     // interfaces::bot（傳輸層細節），實際的 Telegram adapter 由 main 啟動時註冊。
@@ -125,6 +126,14 @@ async fn run_cron(sched: &JobScheduler) -> Result<()> {
         ),
         // 05:30 更新台股 ETF 資訊
         create_job("0 30 5 * * *", "更新台股 ETF 資訊", etf::execute),
+        // 05:40 計算各期間年化報酬率(CAGR)
+        // 必須排在 21:00 年度配息回補與 05:00~05:30 各項回補之後，
+        // 否則當日結果會少算前一晚才補進來的股利
+        create_job(
+            "0 40 5 * * *",
+            "計算各期間年化報酬率(CAGR)",
+            calculation::cagr::execute_scheduled,
+        ),
         // 08:00 提醒本日除權息與明日預計除權息的股票
         create_job(
             "0 0 8 * * *",

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -4,6 +4,7 @@ pub mod events;
 pub mod financial;
 pub mod market_index;
 pub mod money_flow;
+pub mod performance;
 pub mod portfolio;
 pub mod quote;
 pub mod registry;

--- a/src/domain/performance/entity.rs
+++ b/src/domain/performance/entity.rs
@@ -35,13 +35,15 @@ pub enum CagrPeriod {
     Y3,
     /// 5 年。
     Y5,
+    /// 7 年。
+    Y7,
     /// 10 年。
     Y10,
 }
 
 impl CagrPeriod {
     /// 全部期間，依長度由短至長排列。
-    pub const ALL: [CagrPeriod; 8] = [
+    pub const ALL: [CagrPeriod; 9] = [
         CagrPeriod::M3,
         CagrPeriod::M6,
         CagrPeriod::Y1,
@@ -49,6 +51,7 @@ impl CagrPeriod {
         CagrPeriod::Y2,
         CagrPeriod::Y3,
         CagrPeriod::Y5,
+        CagrPeriod::Y7,
         CagrPeriod::Y10,
     ];
 
@@ -62,6 +65,7 @@ impl CagrPeriod {
             CagrPeriod::Y2 => "Y2",
             CagrPeriod::Y3 => "Y3",
             CagrPeriod::Y5 => "Y5",
+            CagrPeriod::Y7 => "Y7",
             CagrPeriod::Y10 => "Y10",
         }
     }
@@ -81,6 +85,7 @@ impl CagrPeriod {
             CagrPeriod::Y2 => 24,
             CagrPeriod::Y3 => 36,
             CagrPeriod::Y5 => 60,
+            CagrPeriod::Y7 => 84,
             CagrPeriod::Y10 => 120,
         }
     }
@@ -95,6 +100,7 @@ impl CagrPeriod {
             CagrPeriod::Y2 => "2 年",
             CagrPeriod::Y3 => "3 年",
             CagrPeriod::Y5 => "5 年",
+            CagrPeriod::Y7 => "7 年",
             CagrPeriod::Y10 => "10 年",
         }
     }
@@ -109,7 +115,7 @@ impl CagrPeriod {
 
     /// 是否適合作為預設曝露的期間。
     ///
-    /// Y5／Y10 的樣本涵蓋率僅約 6 成（2026-08-07 實測 65.1%／59.0%），
+    /// Y5／Y7／Y10 的樣本涵蓋率僅約 6 成（2026-08-07 實測 Y5 65.1%、Y10 59.0%），
     /// 可以提供但不宜預設，且展示時必須揭露樣本涵蓋率與存活者偏誤。
     pub fn is_default_exposed(&self) -> bool {
         self.months() <= 36
@@ -320,7 +326,7 @@ mod tests {
             );
             assert!(!period.display_name().is_empty());
         }
-        assert_eq!(CagrPeriod::from_code("Y7"), None);
+        assert_eq!(CagrPeriod::from_code("Y8"), None);
         // 小寫不視為合法代碼，避免資料庫寫入大小寫混雜的值。
         assert_eq!(CagrPeriod::from_code("y1"), None);
     }
@@ -346,7 +352,7 @@ mod tests {
     #[test]
     fn long_periods_require_coverage_disclosure_and_drop_price_metric() {
         // Y5/Y10 涵蓋率僅約六成，且長期間配股普遍，兩項限制必須同時成立。
-        for period in [CagrPeriod::Y5, CagrPeriod::Y10] {
+        for period in [CagrPeriod::Y5, CagrPeriod::Y7, CagrPeriod::Y10] {
             assert!(!period.is_default_exposed());
             assert!(period.requires_coverage_disclosure());
             assert!(!period.supports_price_metric());

--- a/src/domain/performance/entity.rs
+++ b/src/domain/performance/entity.rs
@@ -1,0 +1,302 @@
+use chrono::NaiveDate;
+use rust_decimal::Decimal;
+
+/// 固定投入金額（元）。所有 CAGR 模擬皆以此金額為期初投入。
+pub const PRINCIPAL: i64 = 10_000;
+
+/// 期初日對齊的寬限天數。
+///
+/// 名目期初目標日若無報價（例如該股當時尚未上市、或恰逢停牌），
+/// 允許往後找最多這麼多天內的第一筆報價作為實際期初日；
+/// 超出此範圍即視為資料不足，不予計算。
+pub const BASE_DATE_GRACE_DAYS: i64 = 30;
+
+/// 股票股利的面額（元）。配股率 = 每股股票股利 / 面額。
+pub const PAR_VALUE: i64 = 10;
+
+/// CAGR 統計期間。
+///
+/// 期間長度由 [`CagrPeriod::months`] 定義（以月為單位回推），
+/// 實際年數則一律以「期末交易日 − 期初交易日」的日數差計算，
+/// 不使用此處的名目長度，避免假日對齊造成系統性偏差。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum CagrPeriod {
+    /// 3 個月。
+    M3,
+    /// 6 個月。
+    M6,
+    /// 1 年。
+    Y1,
+    /// 1 年 6 個月。
+    Y1H,
+    /// 2 年。
+    Y2,
+    /// 3 年。
+    Y3,
+    /// 5 年。
+    Y5,
+    /// 10 年。
+    Y10,
+}
+
+impl CagrPeriod {
+    /// 全部期間，依長度由短至長排列。
+    pub const ALL: [CagrPeriod; 8] = [
+        CagrPeriod::M3,
+        CagrPeriod::M6,
+        CagrPeriod::Y1,
+        CagrPeriod::Y1H,
+        CagrPeriod::Y2,
+        CagrPeriod::Y3,
+        CagrPeriod::Y5,
+        CagrPeriod::Y10,
+    ];
+
+    /// 資料庫與 API 使用的期間代碼。
+    pub fn code(&self) -> &'static str {
+        match self {
+            CagrPeriod::M3 => "M3",
+            CagrPeriod::M6 => "M6",
+            CagrPeriod::Y1 => "Y1",
+            CagrPeriod::Y1H => "Y1H",
+            CagrPeriod::Y2 => "Y2",
+            CagrPeriod::Y3 => "Y3",
+            CagrPeriod::Y5 => "Y5",
+            CagrPeriod::Y10 => "Y10",
+        }
+    }
+
+    /// 自期間代碼還原，無法辨識時回傳 `None`。
+    pub fn from_code(code: &str) -> Option<CagrPeriod> {
+        CagrPeriod::ALL.into_iter().find(|p| p.code() == code)
+    }
+
+    /// 期初目標日的回推月數。
+    pub fn months(&self) -> u32 {
+        match self {
+            CagrPeriod::M3 => 3,
+            CagrPeriod::M6 => 6,
+            CagrPeriod::Y1 => 12,
+            CagrPeriod::Y1H => 18,
+            CagrPeriod::Y2 => 24,
+            CagrPeriod::Y3 => 36,
+            CagrPeriod::Y5 => 60,
+            CagrPeriod::Y10 => 120,
+        }
+    }
+
+    /// 顯示用的中文名稱。
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            CagrPeriod::M3 => "3 個月",
+            CagrPeriod::M6 => "6 個月",
+            CagrPeriod::Y1 => "1 年",
+            CagrPeriod::Y1H => "1 年 6 個月",
+            CagrPeriod::Y2 => "2 年",
+            CagrPeriod::Y3 => "3 年",
+            CagrPeriod::Y5 => "5 年",
+            CagrPeriod::Y10 => "10 年",
+        }
+    }
+
+    /// 年化數值是否具備參考意義。
+    ///
+    /// 3 個月的年化指數約為 4，單季 +20% 會被放大成 +107%，統計意義薄弱。
+    /// 展示層應依此決定預設以「區間總報酬」或「年化報酬」排序。
+    pub fn annualization_is_meaningful(&self) -> bool {
+        self.months() >= 12
+    }
+
+    /// 是否適合作為預設曝露的期間。
+    ///
+    /// Y5／Y10 的樣本涵蓋率僅約 6 成（2026-08-07 實測 65.1%／59.0%），
+    /// 可以提供但不宜預設，且展示時必須揭露樣本涵蓋率與存活者偏誤。
+    pub fn is_default_exposed(&self) -> bool {
+        self.months() <= 36
+    }
+
+    /// 是否需要在展示層揭露樣本涵蓋限制。
+    pub fn requires_coverage_disclosure(&self) -> bool {
+        !self.is_default_exposed()
+    }
+
+    /// 純價格報酬（口徑 A）在此期間是否仍具參考價值。
+    ///
+    /// 2026-08-07 實測顯示近十年每年皆有 134–216 檔股票配股，
+    /// 期間愈長，忽略配股造成的低估愈嚴重，故長期間不提供此口徑。
+    pub fn supports_price_metric(&self) -> bool {
+        self.months() <= 36
+    }
+}
+
+/// 報酬口徑。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CagrMetric {
+    /// A：純價格報酬，忽略所有除權息。
+    Price,
+    /// B：含息不再投入 —— 配股自動入帳，現金股利累積不動。主指標。
+    Total,
+    /// C：含息再投入 —— 現金股利於除息日以當日收盤價買回。
+    Reinvested,
+}
+
+impl CagrMetric {
+    /// 全部口徑。
+    pub const ALL: [CagrMetric; 3] = [
+        CagrMetric::Price,
+        CagrMetric::Total,
+        CagrMetric::Reinvested,
+    ];
+
+    /// API 與查詢參數使用的代碼。
+    pub fn code(&self) -> &'static str {
+        match self {
+            CagrMetric::Price => "price",
+            CagrMetric::Total => "total",
+            CagrMetric::Reinvested => "reinvested",
+        }
+    }
+
+    /// 自代碼還原，無法辨識時回傳 `None`。
+    pub fn from_code(code: &str) -> Option<CagrMetric> {
+        CagrMetric::ALL.into_iter().find(|m| m.code() == code)
+    }
+}
+
+/// 單一除權息事件。
+///
+/// 現金與股票股利各有獨立的除權息日，兩者可能不同日甚至只有其中之一，
+/// 因此以兩個 `Option<NaiveDate>` 表達，由模擬器各自判定是否落在期間內。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DividendEvent {
+    /// 股票代號。
+    pub stock_symbol: String,
+    /// 除息日（現金股利）。無效或未公布時為 `None`。
+    pub ex_dividend_date_cash: Option<NaiveDate>,
+    /// 除權日（股票股利）。無效或未公布時為 `None`。
+    pub ex_dividend_date_stock: Option<NaiveDate>,
+    /// 每股現金股利（元）。
+    pub cash_dividend: Decimal,
+    /// 每股股票股利（元，面額 [`PAR_VALUE`]）。
+    pub stock_dividend: Decimal,
+}
+
+impl DividendEvent {
+    /// 事件排序用的日期：取現金與股票除權息日中較早者。
+    ///
+    /// 兩者皆為 `None` 時回傳 `None`，此類事件不應納入模擬。
+    pub fn sort_key(&self) -> Option<NaiveDate> {
+        match (self.ex_dividend_date_cash, self.ex_dividend_date_stock) {
+            (Some(cash), Some(stock)) => Some(cash.min(stock)),
+            (Some(cash), None) => Some(cash),
+            (None, Some(stock)) => Some(stock),
+            (None, None) => None,
+        }
+    }
+}
+
+/// 單一口徑的模擬結果。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SimulationOutcome {
+    /// 期末持有股數（含配股）。
+    pub end_shares: Decimal,
+    /// 累積現金股利（元）。再投入口徑恆為零。
+    pub cash_received: Decimal,
+    /// 期末總價值（元）。
+    pub end_value: Decimal,
+    /// 區間總報酬率（%）。
+    pub total_return_pct: Decimal,
+    /// 年化報酬率（%）。
+    pub cagr_pct: Decimal,
+}
+
+/// 單一股票在單一期間的 CAGR 計算結果 (Aggregate Root)。
+///
+/// 資料不足時 `data_complete` 為 `false`，且所有數值欄位為 `None` ——
+/// 絕不以 0 代替，否則「上市半年的新股」會被誤讀為「十年零報酬」。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StockCagr {
+    /// 計算基準日（期末交易日）。
+    pub date: NaiveDate,
+    /// 股票代號。
+    pub stock_symbol: String,
+    /// 統計期間。
+    pub period: CagrPeriod,
+    /// 實際採用的期初交易日。
+    pub base_date: Option<NaiveDate>,
+    /// 期初收盤價。
+    pub base_price: Option<Decimal>,
+    /// 期末收盤價。
+    pub end_price: Option<Decimal>,
+    /// 實際年數 =（期末交易日 − 期初交易日）/ 365。
+    pub years: Option<Decimal>,
+    /// 口徑 A：純價格報酬。
+    pub price: Option<SimulationOutcome>,
+    /// 口徑 B：含息不再投入。
+    pub total: Option<SimulationOutcome>,
+    /// 口徑 C：含息再投入。
+    pub reinvested: Option<SimulationOutcome>,
+    /// 該股在 `DailyQuotes` 的最早報價日，用於判定新上市／資料未涵蓋。
+    pub first_quote_date: Option<NaiveDate>,
+    /// `base_date` 較名目期初目標日晚幾天；0 表完全對齊。
+    pub shortfall_days: Option<i32>,
+    /// 期初資料是否齊全。
+    pub data_complete: bool,
+    /// 期間內偵測到無對應除權息的異常跳動（疑似減資或分割）。
+    pub has_anomaly: bool,
+    /// 期間內實際採計的除權息次數。
+    pub dividend_events: i32,
+}
+
+/// 指定基準日與期間的樣本涵蓋統計。
+///
+/// 長期間（Y5／Y10）的可算比例僅約 6 成，展示層必須揭露此資訊，
+/// 使用者才知道排行榜的分母是什麼、以及存活者偏誤的存在。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CagrCoverage {
+    /// 母體檔數（未下市）。
+    pub universe: i64,
+    /// 實際可算檔數。
+    pub counted: i64,
+    /// 資料不足檔數。
+    pub incomplete: i64,
+    /// 標記為疑似異常的檔數。
+    pub anomaly_flagged: i64,
+    /// 可算檔數中報酬為正的檔數。
+    pub positive: i64,
+}
+
+impl CagrCoverage {
+    /// 樣本涵蓋率 = 可算檔數 / 母體檔數。母體為零時回傳零。
+    pub fn coverage_ratio(&self) -> Decimal {
+        if self.universe == 0 {
+            return Decimal::ZERO;
+        }
+        Decimal::from(self.counted) / Decimal::from(self.universe)
+    }
+
+    /// 正報酬比例 = 正報酬檔數 / **可算檔數**。
+    ///
+    /// 分母刻意為 `counted` 而非 `universe` —— 混用會安靜地得到偏低的數字。
+    pub fn positive_ratio(&self) -> Decimal {
+        if self.counted == 0 {
+            return Decimal::ZERO;
+        }
+        Decimal::from(self.positive) / Decimal::from(self.counted)
+    }
+}
+
+impl crate::core::util::map::Keyable for StockCagr {
+    fn key(&self) -> String {
+        format!("{}-{}-{}", self.stock_symbol, self.date, self.period.code())
+    }
+
+    fn key_with_prefix(&self) -> String {
+        format!(
+            "StockCagr:{}-{}-{}",
+            self.stock_symbol,
+            self.date,
+            self.period.code()
+        )
+    }
+}

--- a/src/domain/performance/entity.rs
+++ b/src/domain/performance/entity.rs
@@ -299,3 +299,148 @@ impl crate::core::util::map::Keyable for StockCagr {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::util::map::Keyable;
+
+    fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).expect("測試日期應合法")
+    }
+
+    #[test]
+    fn period_code_round_trips_and_rejects_unknown() {
+        for period in CagrPeriod::ALL {
+            assert_eq!(
+                CagrPeriod::from_code(period.code()),
+                Some(period),
+                "{} 應能由代碼還原",
+                period.code()
+            );
+            assert!(!period.display_name().is_empty());
+        }
+        assert_eq!(CagrPeriod::from_code("Y7"), None);
+        // 小寫不視為合法代碼，避免資料庫寫入大小寫混雜的值。
+        assert_eq!(CagrPeriod::from_code("y1"), None);
+    }
+
+    #[test]
+    fn period_all_is_ordered_from_short_to_long() {
+        let months: Vec<u32> = CagrPeriod::ALL.iter().map(|p| p.months()).collect();
+        let mut sorted = months.clone();
+        sorted.sort_unstable();
+        assert_eq!(months, sorted, "ALL 必須依期間長度由短至長排列");
+        assert_eq!(months.first(), Some(&3));
+        assert_eq!(months.last(), Some(&120));
+    }
+
+    #[test]
+    fn short_periods_do_not_claim_meaningful_annualization() {
+        assert!(!CagrPeriod::M3.annualization_is_meaningful());
+        assert!(!CagrPeriod::M6.annualization_is_meaningful());
+        assert!(CagrPeriod::Y1.annualization_is_meaningful());
+        assert!(CagrPeriod::Y10.annualization_is_meaningful());
+    }
+
+    #[test]
+    fn long_periods_require_coverage_disclosure_and_drop_price_metric() {
+        // Y5/Y10 涵蓋率僅約六成，且長期間配股普遍，兩項限制必須同時成立。
+        for period in [CagrPeriod::Y5, CagrPeriod::Y10] {
+            assert!(!period.is_default_exposed());
+            assert!(period.requires_coverage_disclosure());
+            assert!(!period.supports_price_metric());
+        }
+        for period in [CagrPeriod::M3, CagrPeriod::Y1, CagrPeriod::Y3] {
+            assert!(period.is_default_exposed());
+            assert!(!period.requires_coverage_disclosure());
+            assert!(period.supports_price_metric());
+        }
+    }
+
+    #[test]
+    fn metric_code_round_trips_and_rejects_unknown() {
+        for metric in CagrMetric::ALL {
+            assert_eq!(CagrMetric::from_code(metric.code()), Some(metric));
+        }
+        assert_eq!(CagrMetric::from_code("gross"), None);
+    }
+
+    #[test]
+    fn dividend_event_sort_key_takes_the_earlier_of_two_dates() {
+        let make = |cash: Option<NaiveDate>, stock: Option<NaiveDate>| DividendEvent {
+            stock_symbol: "2330".to_string(),
+            ex_dividend_date_cash: cash,
+            ex_dividend_date_stock: stock,
+            cash_dividend: Decimal::ZERO,
+            stock_dividend: Decimal::ZERO,
+        };
+        let cash_day = date(2024, 6, 20);
+        let stock_day = date(2024, 7, 15);
+
+        assert_eq!(
+            make(Some(cash_day), Some(stock_day)).sort_key(),
+            Some(cash_day)
+        );
+        assert_eq!(
+            make(Some(stock_day), Some(cash_day)).sort_key(),
+            Some(cash_day)
+        );
+        assert_eq!(make(Some(cash_day), None).sort_key(), Some(cash_day));
+        assert_eq!(make(None, Some(stock_day)).sort_key(), Some(stock_day));
+        // 兩個日期都缺的事件不應納入模擬，因此沒有排序鍵。
+        assert_eq!(make(None, None).sort_key(), None);
+    }
+
+    #[test]
+    fn coverage_ratio_uses_universe_and_positive_ratio_uses_counted() {
+        let coverage = CagrCoverage {
+            universe: 200,
+            counted: 100,
+            incomplete: 100,
+            anomaly_flagged: 5,
+            positive: 40,
+        };
+        assert_eq!(coverage.coverage_ratio(), Decimal::new(5, 1)); // 100/200
+        // 分母若誤用 universe 會得到 0.2，這裡確保是 counted。
+        assert_eq!(coverage.positive_ratio(), Decimal::new(4, 1)); // 40/100
+    }
+
+    #[test]
+    fn coverage_ratios_are_zero_when_denominator_is_zero() {
+        let empty = CagrCoverage::default();
+        assert_eq!(empty.coverage_ratio(), Decimal::ZERO);
+        assert_eq!(empty.positive_ratio(), Decimal::ZERO);
+
+        // 母體不為零但可算數為零時，正報酬比例仍必須是零而非除以零。
+        let none_counted = CagrCoverage {
+            universe: 10,
+            ..Default::default()
+        };
+        assert_eq!(none_counted.coverage_ratio(), Decimal::ZERO);
+        assert_eq!(none_counted.positive_ratio(), Decimal::ZERO);
+    }
+
+    #[test]
+    fn stock_cagr_key_includes_symbol_date_and_period() {
+        let record = StockCagr {
+            date: date(2026, 8, 7),
+            stock_symbol: "2330".to_string(),
+            period: CagrPeriod::Y1H,
+            base_date: None,
+            base_price: None,
+            end_price: None,
+            years: None,
+            price: None,
+            total: None,
+            reinvested: None,
+            first_quote_date: None,
+            shortfall_days: None,
+            data_complete: false,
+            has_anomaly: false,
+            dividend_events: 0,
+        };
+        assert_eq!(record.key(), "2330-2026-08-07-Y1H");
+        assert_eq!(record.key_with_prefix(), "StockCagr:2330-2026-08-07-Y1H");
+    }
+}

--- a/src/domain/performance/entity.rs
+++ b/src/domain/performance/entity.rs
@@ -132,7 +132,7 @@ impl CagrPeriod {
 /// 報酬口徑。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CagrMetric {
-    /// A：純價格報酬，忽略所有除權息。
+    /// A：純價格報酬，忽略所有除權息。此口徑的 `cash_received` 恆為零。
     Price,
     /// B：含息不再投入 —— 配股自動入帳，現金股利累積不動。主指標。
     Total,
@@ -142,11 +142,7 @@ pub enum CagrMetric {
 
 impl CagrMetric {
     /// 全部口徑。
-    pub const ALL: [CagrMetric; 3] = [
-        CagrMetric::Price,
-        CagrMetric::Total,
-        CagrMetric::Reinvested,
-    ];
+    pub const ALL: [CagrMetric; 3] = [CagrMetric::Price, CagrMetric::Total, CagrMetric::Reinvested];
 
     /// API 與查詢參數使用的代碼。
     pub fn code(&self) -> &'static str {
@@ -200,7 +196,10 @@ impl DividendEvent {
 pub struct SimulationOutcome {
     /// 期末持有股數（含配股）。
     pub end_shares: Decimal,
-    /// 累積現金股利（元）。再投入口徑恆為零。
+    /// 累積現金股利（元）。
+    ///
+    /// 再投入口徑通常為零（股利都買回股數了），但除息日查無收盤價而無法買回
+    /// 時，該次股利會退回現金累積 —— 不可丟棄 —— 此時不為零。
     pub cash_received: Decimal,
     /// 期末總價值（元）。
     pub end_value: Decimal,

--- a/src/domain/performance/mod.rs
+++ b/src/domain/performance/mod.rs
@@ -1,0 +1,11 @@
+/// 績效指標領域實體子模組。
+pub mod entity;
+/// 績效指標倉儲合約子模組。
+pub mod repository;
+/// 固定投入金額的報酬模擬器（純函式，無 I/O）。
+pub mod simulator;
+
+pub use entity::{
+    CagrCoverage, CagrMetric, CagrPeriod, DividendEvent, SimulationOutcome, StockCagr,
+};
+pub use repository::CagrRepository;

--- a/src/domain/performance/mod.rs
+++ b/src/domain/performance/mod.rs
@@ -1,11 +1,18 @@
 /// 績效指標領域實體子模組。
 pub mod entity;
+/// 排行榜查詢條件與結果子模組。
+pub mod query;
 /// 績效指標倉儲合約子模組。
 pub mod repository;
 /// 固定投入金額的報酬模擬器（純函式，無 I/O）。
 pub mod simulator;
+/// CAGR 計算所需之原始資料來源合約子模組。
+pub mod source;
 
 pub use entity::{
-    CagrCoverage, CagrMetric, CagrPeriod, DividendEvent, SimulationOutcome, StockCagr,
+    BASE_DATE_GRACE_DAYS, CagrCoverage, CagrMetric, CagrPeriod, DividendEvent, PAR_VALUE,
+    PRINCIPAL, SimulationOutcome, StockCagr,
 };
+pub use query::{CagrRankingItem, CagrRankingPage, CagrRankingQuery, CagrSortKey};
 pub use repository::CagrRepository;
+pub use source::CagrSourceRepository;

--- a/src/domain/performance/query.rs
+++ b/src/domain/performance/query.rs
@@ -119,3 +119,58 @@ pub struct CagrRankingPage {
     /// 樣本涵蓋統計。
     pub coverage: CagrCoverage,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).expect("測試日期應合法")
+    }
+
+    #[test]
+    fn sort_key_code_round_trips_and_rejects_unknown() {
+        for key in CagrSortKey::ALL {
+            assert_eq!(CagrSortKey::from_code(key.code()), Some(key));
+        }
+        assert_eq!(CagrSortKey::from_code("total_cagr_pct"), None);
+        assert_eq!(CagrSortKey::default(), CagrSortKey::Cagr);
+    }
+
+    #[test]
+    fn short_periods_default_to_total_return() {
+        // 3M/6M 年化後會被放大約四倍，預設排序必須退回區間總報酬。
+        assert_eq!(
+            CagrSortKey::default_for(CagrPeriod::M3),
+            CagrSortKey::TotalReturn
+        );
+        assert_eq!(
+            CagrSortKey::default_for(CagrPeriod::M6),
+            CagrSortKey::TotalReturn
+        );
+        for period in [CagrPeriod::Y1, CagrPeriod::Y3, CagrPeriod::Y10] {
+            assert_eq!(CagrSortKey::default_for(period), CagrSortKey::Cagr);
+        }
+    }
+
+    #[test]
+    fn new_query_uses_total_metric_and_includes_incomplete() {
+        let query = CagrRankingQuery::new(date(2026, 8, 7), CagrPeriod::Y1);
+
+        assert_eq!(query.metric, CagrMetric::Total);
+        assert_eq!(query.sort, CagrSortKey::Cagr);
+        // 「查得到但算不出來」與「查不到」是兩件事，預設不可濾掉前者。
+        assert!(query.include_incomplete);
+        assert_eq!(query.limit, 50);
+        assert_eq!(query.offset, 0);
+        assert!(query.market_id.is_none());
+        assert!(query.industry_id.is_none());
+        assert!(query.keyword.is_none());
+    }
+
+    #[test]
+    fn new_query_picks_sort_key_from_period_length() {
+        let short = CagrRankingQuery::new(date(2026, 8, 7), CagrPeriod::M3);
+        assert_eq!(short.sort, CagrSortKey::TotalReturn);
+    }
+}

--- a/src/domain/performance/query.rs
+++ b/src/domain/performance/query.rs
@@ -1,0 +1,121 @@
+use chrono::NaiveDate;
+
+use crate::domain::performance::entity::{CagrCoverage, CagrMetric, CagrPeriod, StockCagr};
+
+/// 排行榜排序鍵。
+///
+/// 短期間（3M／6M）年化後會被放大約 4 倍，單季 +20% 會變成 +107%，
+/// 統計意義薄弱，因此展示層在短期間應改用 [`CagrSortKey::TotalReturn`]。
+/// 這裡以列舉而非字串表達，讓「排序鍵」在型別層面就是封閉集合，
+/// SQL 端只能對應到白名單內的欄位字面值，不存在拼接注入的空間。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CagrSortKey {
+    /// 依年化報酬率排序。
+    #[default]
+    Cagr,
+    /// 依區間總報酬率排序。
+    TotalReturn,
+}
+
+impl CagrSortKey {
+    /// 全部排序鍵。
+    pub const ALL: [CagrSortKey; 2] = [CagrSortKey::Cagr, CagrSortKey::TotalReturn];
+
+    /// API 查詢參數使用的代碼。
+    pub fn code(&self) -> &'static str {
+        match self {
+            CagrSortKey::Cagr => "cagr",
+            CagrSortKey::TotalReturn => "total_return",
+        }
+    }
+
+    /// 自代碼還原，無法辨識時回傳 `None`。
+    pub fn from_code(code: &str) -> Option<CagrSortKey> {
+        CagrSortKey::ALL.into_iter().find(|k| k.code() == code)
+    }
+
+    /// 依期間長度決定合適的預設排序鍵。
+    pub fn default_for(period: CagrPeriod) -> CagrSortKey {
+        if period.annualization_is_meaningful() {
+            CagrSortKey::Cagr
+        } else {
+            CagrSortKey::TotalReturn
+        }
+    }
+}
+
+/// 排行榜查詢條件。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CagrRankingQuery {
+    /// 計算基準日。
+    pub date: NaiveDate,
+    /// 統計期間。
+    pub period: CagrPeriod,
+    /// 報酬口徑。
+    pub metric: CagrMetric,
+    /// 排序鍵。
+    pub sort: CagrSortKey,
+    /// 交易所市場編號篩選（`None` 表全部）。
+    pub market_id: Option<i32>,
+    /// 產業分類編號篩選（`None` 表全部）。
+    pub industry_id: Option<i32>,
+    /// 代號或名稱關鍵字篩選。
+    pub keyword: Option<String>,
+    /// 是否一併回傳資料不足的項目。
+    ///
+    /// 預設為 `true`：「查得到但算不出來」與「查不到」是兩件不同的事，
+    /// 直接濾掉會讓使用者困惑於自己持有的股票為何消失。
+    pub include_incomplete: bool,
+    /// 單頁筆數。
+    pub limit: i64,
+    /// 起始位移。
+    pub offset: i64,
+}
+
+impl CagrRankingQuery {
+    /// 以基準日與期間建立預設查詢：主指標口徑、依期間長度決定排序鍵。
+    pub fn new(date: NaiveDate, period: CagrPeriod) -> Self {
+        Self {
+            date,
+            period,
+            metric: CagrMetric::Total,
+            sort: CagrSortKey::default_for(period),
+            market_id: None,
+            industry_id: None,
+            keyword: None,
+            include_incomplete: true,
+            limit: 50,
+            offset: 0,
+        }
+    }
+}
+
+/// 排行榜中的單一項目。
+///
+/// 在 [`StockCagr`] 之外附上展示所需的股票名稱與名次 —— 這兩者不屬於
+/// 計算結果本身，但少了它們前端得再查一次股票母檔。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CagrRankingItem {
+    /// 計算結果。
+    pub cagr: StockCagr,
+    /// 股票名稱。
+    pub name: String,
+    /// 產業分類編號。
+    pub industry_id: i32,
+    /// 名次。
+    ///
+    /// 資料不足者為 `None` —— 這類項目不佔名次且排在所有可算項目之後，
+    /// 否則排行榜會出現「第 1204 名，報酬率 —」這種無意義的列。
+    pub rank: Option<i64>,
+}
+
+/// 排行榜查詢結果。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CagrRankingPage {
+    /// 本頁項目。
+    pub items: Vec<CagrRankingItem>,
+    /// 符合篩選條件的總筆數（供分頁計算）。
+    pub total: i64,
+    /// 樣本涵蓋統計。
+    pub coverage: CagrCoverage,
+}

--- a/src/domain/performance/repository.rs
+++ b/src/domain/performance/repository.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use chrono::NaiveDate;
 
 use crate::domain::performance::entity::{CagrCoverage, CagrMetric, CagrPeriod, StockCagr};
+use crate::domain::performance::query::{CagrRankingPage, CagrRankingQuery};
 
 /// 績效指標領域之倉儲介面 (Repository Trait)。
 ///
@@ -20,6 +21,9 @@ pub trait CagrRepository: Send + Sync {
     /// 取得指定基準日與期間的排行榜，依指定口徑的年化報酬率由高至低排序。
     ///
     /// 僅回傳 `data_complete = true` 的資料；資料不足者由呼叫端另行查詢。
+    /// 指定口徑的 `*_cagr_pct` 為 NULL 者一併排除 —— 長期間不提供純價格口徑
+    /// （見 [`CagrPeriod::supports_price_metric`]），會出現 `data_complete = true`
+    /// 但該口徑為 NULL 的列。
     async fn fetch_ranking(
         &self,
         date: NaiveDate,
@@ -29,11 +33,30 @@ pub trait CagrRepository: Send + Sync {
         offset: i64,
     ) -> Result<Vec<StockCagr>>;
 
+    /// 依完整查詢條件取得排行榜單頁結果（含篩選、總筆數與樣本涵蓋統計）。
+    ///
+    /// 與 [`Self::fetch_ranking`] 的差別在於這是給 API 用的完整查詢：支援市場、
+    /// 產業、關鍵字篩選，回傳股票名稱與名次，並一併帶出分頁所需的總筆數。
+    ///
+    /// 實作要求：
+    ///
+    /// - `include_incomplete` 為 `true` 時，資料不足的項目要一併回傳，
+    ///   但 `rank` 為 `None` 且**排在所有可算項目之後**。
+    /// - 排序鍵與排序欄位必須以白名單對應到字面值，不得字串拼接。
+    async fn fetch_ranking_page(&self, query: &CagrRankingQuery) -> Result<CagrRankingPage>;
+
     /// 取得單一個股在指定基準日的所有期間結果（含資料不足者）。
-    async fn fetch_by_symbol(&self, date: NaiveDate, stock_symbol: &str)
-    -> Result<Vec<StockCagr>>;
+    ///
+    /// 結果必須依**期間長度**（[`CagrPeriod::months`]）由短至長排序。注意不能
+    /// 用資料庫端的 `period` 字串排序 —— 字典序會把 `Y10` 排在 `Y1H` 之前。
+    async fn fetch_by_symbol(&self, date: NaiveDate, stock_symbol: &str) -> Result<Vec<StockCagr>>;
 
     /// 取得指定基準日與期間的樣本涵蓋統計。
+    ///
+    /// `universe` 取自該 `(date, period)` 的資料列數，因此**計算層必須為母體中
+    /// 每一檔股票都寫入一列**（資料不足者寫 `data_complete = false` 的 NULL 列）。
+    /// 若略過不寫，`universe` 會退化成「有寫入的檔數」，涵蓋率被系統性高估 ——
+    /// 而涵蓋率正是 Y5／Y10 揭露存活者偏誤的依據，高估等於掩蓋問題。
     async fn fetch_coverage(
         &self,
         date: NaiveDate,

--- a/src/domain/performance/repository.rs
+++ b/src/domain/performance/repository.rs
@@ -67,6 +67,13 @@ pub trait CagrRepository: Send + Sync {
     /// 取得最新一個已完成計算的基準日。尚無資料時回傳 `None`。
     async fn fetch_latest_date(&self) -> Result<Option<NaiveDate>>;
 
+    /// 取得「已有計算結果、但缺少指定期間」的基準日，由早至晚排序。
+    ///
+    /// 用於新增統計期間後回填歷史：既有基準日不會自動長出新期間的資料，
+    /// 但也不該把從未計算過的日期一併算進來 —— 那是另一回事（歷史初始化），
+    /// 範圍與成本都完全不同。
+    async fn fetch_dates_missing_period(&self, period: CagrPeriod) -> Result<Vec<NaiveDate>>;
+
     /// 刪除早於指定日期的歷史資料，回傳刪除筆數。
     async fn delete_before(&self, date: NaiveDate) -> Result<u64>;
 }

--- a/src/domain/performance/repository.rs
+++ b/src/domain/performance/repository.rs
@@ -1,0 +1,49 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::NaiveDate;
+
+use crate::domain::performance::entity::{CagrCoverage, CagrMetric, CagrPeriod, StockCagr};
+
+/// 績效指標領域之倉儲介面 (Repository Trait)。
+///
+/// 隔離 PostgreSQL 存取細節，定義每日 CAGR 計算結果的讀寫合約。
+#[async_trait]
+pub trait CagrRepository: Send + Sync {
+    /// 批次寫入或更新指定基準日的 CAGR 計算結果。
+    ///
+    /// 同一 `(date, stock_symbol, period)` 重複執行必須是冪等的
+    /// （以 upsert 覆蓋），讓同日重跑可以修正先前的結果。
+    ///
+    /// 回傳實際寫入的資料筆數。
+    async fn save_batch(&self, records: &[StockCagr]) -> Result<u64>;
+
+    /// 取得指定基準日與期間的排行榜，依指定口徑的年化報酬率由高至低排序。
+    ///
+    /// 僅回傳 `data_complete = true` 的資料；資料不足者由呼叫端另行查詢。
+    async fn fetch_ranking(
+        &self,
+        date: NaiveDate,
+        period: CagrPeriod,
+        metric: CagrMetric,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<StockCagr>>;
+
+    /// 取得單一個股在指定基準日的所有期間結果（含資料不足者）。
+    async fn fetch_by_symbol(&self, date: NaiveDate, stock_symbol: &str)
+    -> Result<Vec<StockCagr>>;
+
+    /// 取得指定基準日與期間的樣本涵蓋統計。
+    async fn fetch_coverage(
+        &self,
+        date: NaiveDate,
+        period: CagrPeriod,
+        metric: CagrMetric,
+    ) -> Result<CagrCoverage>;
+
+    /// 取得最新一個已完成計算的基準日。尚無資料時回傳 `None`。
+    async fn fetch_latest_date(&self) -> Result<Option<NaiveDate>>;
+
+    /// 刪除早於指定日期的歷史資料，回傳刪除筆數。
+    async fn delete_before(&self, date: NaiveDate) -> Result<u64>;
+}

--- a/src/domain/performance/simulator.rs
+++ b/src/domain/performance/simulator.rs
@@ -1,7 +1,8 @@
 use chrono::NaiveDate;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 
-use crate::domain::performance::entity::{DividendEvent, SimulationOutcome};
+use crate::domain::performance::entity::{DividendEvent, PAR_VALUE, SimulationOutcome};
 
 /// 模擬所需的輸入。
 ///
@@ -42,6 +43,31 @@ pub struct SimulationResult {
     pub dividend_events: i32,
 }
 
+/// 除權息動作的種類。
+///
+/// 一筆 [`DividendEvent`] 的現金與股票除權息日可能不同日，因此模擬時
+/// 必須先把事件「拆解」成獨立帶日期的動作，再全部混合排序後逐筆套用。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum ActionKind {
+    /// 除息（發放現金股利）。同日時排在除權之前。
+    Cash,
+    /// 除權（發放股票股利）。
+    Stock,
+}
+
+/// 拆解後的單一除權息動作。
+#[derive(Debug, Clone, Copy)]
+struct DividendAction {
+    /// 動作發生日。
+    date: NaiveDate,
+    /// 動作種類。
+    kind: ActionKind,
+    /// 每股金額（現金股利元數，或股票股利元數）。
+    amount: Decimal,
+    /// 來源事件在 `events` 中的索引，用於統計採計事件筆數。
+    event_index: usize,
+}
+
 /// 依固定投入金額模擬三種口徑的期末價值與報酬率。
 ///
 /// # 計算規則
@@ -52,13 +78,172 @@ pub struct SimulationResult {
 /// - 配股率 = 每股股票股利 / 面額 10 元。
 /// - 事件生效條件為除權息日落在 `(base_date, end_date]` 區間內。
 ///
+/// # 事件時序約定
+///
+/// 一筆事件的現金除息日與股票除權日可能不同日，故實作上先把每筆事件拆成
+/// 最多兩個 [`DividendAction`]（除息、除權），全部混合後依「日期 → 種類」
+/// 排序再逐筆套用。**同一日同時除息與除權時，約定先除息、後除權**：
+/// 台股實務上現金股利是以除權息基準日的持股計算，配股在同一日入帳並不會
+/// 增加當次可領的現金股利，因此除息必須先於除權生效。
+///
+/// # `dividend_events` 的定義
+///
+/// 統計的是「**至少有一個動作實際生效**（日期落在區間內且金額大於零）的
+/// [`DividendEvent`] 筆數」，而非動作數。因此一筆同時除息又除權的事件
+/// 只計 1 次。
+///
+/// # 口徑差異
+///
+/// - A `price`：完全忽略除權息，股數固定為 `principal / base_price`。
+/// - B `total`：配股增加股數，現金股利累積為現金不再投入。
+/// - C `reinvested`：配股同 B；現金股利於除息日以當日收盤價買回股數。
+///   查無該日價格時該次股利退回現金累積（不可丟棄），此時 `cash_received`
+///   不為零。
+///
 /// # Errors
 ///
-/// `base_price` 或 `end_price` 非正數、或 `end_date <= base_date` 時回傳 `None`。
+/// `principal`、`base_price` 或 `end_price` 非正數、或 `end_date <= base_date`
+/// 時回傳 `None`。
 pub fn simulate(input: &SimulationInput<'_>) -> Option<SimulationResult> {
-    // TODO(M1)：實作於 Agent A。
-    let _ = input;
-    unimplemented!("simulate 尚未實作")
+    if input.principal <= Decimal::ZERO
+        || input.base_price <= Decimal::ZERO
+        || input.end_price <= Decimal::ZERO
+        || input.end_date <= input.base_date
+    {
+        return None;
+    }
+
+    // 年數一律以實際日數差 / 365 計算，避免假日對齊造成系統性偏差。
+    let years =
+        Decimal::from((input.end_date - input.base_date).num_days()) / Decimal::from(365_i64);
+    if years <= Decimal::ZERO {
+        return None;
+    }
+
+    // ── 步驟一：把事件拆解成帶日期的獨立動作 ──────────────────────────
+    let par_value = Decimal::from(PAR_VALUE);
+    let mut actions: Vec<DividendAction> = Vec::with_capacity(input.events.len() * 2);
+    for (index, event) in input.events.iter().enumerate() {
+        // 兩個日期皆為 None（sort_key() 為 None）的事件不會產生任何動作，
+        // 於此自然被安全略過。
+        if let Some(date) = event.ex_dividend_date_cash
+            && event.cash_dividend > Decimal::ZERO
+            && date > input.base_date
+            && date <= input.end_date
+        {
+            actions.push(DividendAction {
+                date,
+                kind: ActionKind::Cash,
+                amount: event.cash_dividend,
+                event_index: index,
+            });
+        }
+
+        if let Some(date) = event.ex_dividend_date_stock
+            && event.stock_dividend > Decimal::ZERO
+            && date > input.base_date
+            && date <= input.end_date
+        {
+            actions.push(DividendAction {
+                date,
+                kind: ActionKind::Stock,
+                amount: event.stock_dividend,
+                event_index: index,
+            });
+        }
+    }
+
+    // ── 步驟二：混合後依「日期 → 種類（除息先於除權）」排序 ────────────
+    actions.sort_by_key(|action| (action.date, action.kind));
+
+    // ── 步驟三：逐筆套用，口徑 B 與 C 共用骨架但各自維護狀態 ───────────
+    let base_shares = input.principal / input.base_price;
+
+    // 口徑 B：含息不再投入。
+    let mut total_shares = base_shares;
+    let mut total_cash = Decimal::ZERO;
+    // 口徑 C：含息再投入。
+    let mut reinvested_shares = base_shares;
+    let mut reinvested_cash = Decimal::ZERO;
+
+    // 採計事件的索引集合（動作數 ≠ 事件數，故需去重）。
+    let mut counted_events: Vec<usize> = Vec::with_capacity(actions.len());
+
+    for action in &actions {
+        match action.kind {
+            ActionKind::Cash => {
+                // 除息：以「事件發生當下」的股數為基數。
+                total_cash += total_shares * action.amount;
+
+                let payout = reinvested_shares * action.amount;
+                match (input.reinvest_prices)(action.date) {
+                    Some(price) if price > Decimal::ZERO => {
+                        reinvested_shares += payout / price;
+                    }
+                    // 查無當日價格（或價格非正數）時退回現金累積，不可丟棄。
+                    _ => reinvested_cash += payout,
+                }
+            }
+            ActionKind::Stock => {
+                // 除權：配股率 = 每股股票股利 / 面額。
+                let rate = action.amount / par_value;
+                total_shares += total_shares * rate;
+                reinvested_shares += reinvested_shares * rate;
+            }
+        }
+
+        if !counted_events.contains(&action.event_index) {
+            counted_events.push(action.event_index);
+        }
+    }
+
+    // ── 步驟四：期末結算 ────────────────────────────────────────────
+    let price_outcome = build_outcome(
+        input.principal,
+        base_shares,
+        Decimal::ZERO,
+        base_shares * input.end_price,
+        years,
+    )?;
+    let total_outcome = build_outcome(
+        input.principal,
+        total_shares,
+        total_cash,
+        total_shares * input.end_price + total_cash,
+        years,
+    )?;
+    let reinvested_outcome = build_outcome(
+        input.principal,
+        reinvested_shares,
+        reinvested_cash,
+        reinvested_shares * input.end_price + reinvested_cash,
+        years,
+    )?;
+
+    Some(SimulationResult {
+        price: price_outcome,
+        total: total_outcome,
+        reinvested: reinvested_outcome,
+        years,
+        dividend_events: counted_events.len() as i32,
+    })
+}
+
+/// 組裝單一口徑的結果，報酬率無法計算時回傳 `None`。
+fn build_outcome(
+    principal: Decimal,
+    end_shares: Decimal,
+    cash_received: Decimal,
+    end_value: Decimal,
+    years: Decimal,
+) -> Option<SimulationOutcome> {
+    Some(SimulationOutcome {
+        end_shares,
+        cash_received,
+        end_value,
+        total_return_pct: total_return_pct(principal, end_value)?,
+        cagr_pct: annualized_return_pct(principal, end_value, years)?,
+    })
 }
 
 /// 以期末價值與年數換算年化報酬率（%）。
@@ -71,14 +256,503 @@ pub fn annualized_return_pct(
     end_value: Decimal,
     years: Decimal,
 ) -> Option<Decimal> {
-    // TODO(M1)：實作於 Agent A。
-    let _ = (principal, end_value, years);
-    unimplemented!("annualized_return_pct 尚未實作")
+    if principal <= Decimal::ZERO || years <= Decimal::ZERO || end_value < Decimal::ZERO {
+        return None;
+    }
+
+    // 期末價值歸零＝全額虧損，年化報酬固定為 -100%（0 的任意次方仍為 0）。
+    if end_value.is_zero() {
+        return Some(Decimal::from(-100_i64));
+    }
+
+    let ratio = (end_value / principal).to_f64()?;
+    let years = years.to_f64()?;
+    if !(ratio.is_finite() && years.is_finite()) || years <= 0.0 {
+        return None;
+    }
+
+    let pct = (ratio.powf(1.0 / years) - 1.0) * 100.0;
+    if !pct.is_finite() {
+        return None;
+    }
+
+    Some(Decimal::from_f64(pct)?.round_dp(4))
 }
 
 /// 以期末價值換算區間總報酬率（%）。
+///
+/// `principal` 非正數時無從定義報酬率，回傳 `None`。
 pub fn total_return_pct(principal: Decimal, end_value: Decimal) -> Option<Decimal> {
-    // TODO(M1)：實作於 Agent A。
-    let _ = (principal, end_value);
-    unimplemented!("total_return_pct 尚未實作")
+    if principal <= Decimal::ZERO {
+        return None;
+    }
+
+    Some(((end_value / principal - Decimal::ONE) * Decimal::from(100_i64)).round_dp(4))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use rust_decimal_macros::dec;
+
+    /// 建立測試用日期。
+    fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).expect("測試日期應合法")
+    }
+
+    /// 建立除權息事件；日期為 `None` 表示該項不存在。
+    fn event(
+        cash_date: Option<NaiveDate>,
+        cash: Decimal,
+        stock_date: Option<NaiveDate>,
+        stock: Decimal,
+    ) -> DividendEvent {
+        DividendEvent {
+            stock_symbol: "2330".to_string(),
+            ex_dividend_date_cash: cash_date,
+            ex_dividend_date_stock: stock_date,
+            cash_dividend: cash,
+            stock_dividend: stock,
+        }
+    }
+
+    /// 建立模擬輸入的輔助結構（避免每個測試重複填欄位）。
+    struct Case<'a> {
+        base_date: NaiveDate,
+        end_date: NaiveDate,
+        base_price: Decimal,
+        end_price: Decimal,
+        events: &'a [DividendEvent],
+    }
+
+    /// 以「再投入永遠查得到固定價格」的方式執行模擬。
+    fn run_with_price(
+        case: &Case<'_>,
+        reinvest_price: Option<Decimal>,
+    ) -> Option<SimulationResult> {
+        let lookup = move |_: NaiveDate| reinvest_price;
+        let input = SimulationInput {
+            principal: dec!(10000),
+            base_date: case.base_date,
+            end_date: case.end_date,
+            base_price: case.base_price,
+            end_price: case.end_price,
+            events: case.events,
+            reinvest_prices: &lookup,
+        };
+        simulate(&input)
+    }
+
+    /// 1. 完全沒有股利時，三種口徑的結果必須完全一致。
+    #[test]
+    fn test_no_dividend_all_metrics_equal() {
+        let case = Case {
+            base_date: date(2020, 1, 2),
+            end_date: date(2021, 1, 2),
+            base_price: dec!(100),
+            end_price: dec!(150),
+            events: &[],
+        };
+        let result = run_with_price(&case, Some(dec!(120))).expect("應可計算");
+
+        // 期初買入 100 股，期末 150 元 → 15,000 元。
+        assert_eq!(result.price.end_shares, dec!(100));
+        assert_eq!(result.price.end_value, dec!(15000));
+        assert_eq!(result.price, result.total);
+        assert_eq!(result.total, result.reinvested);
+        assert_eq!(result.dividend_events, 0);
+        assert_eq!(result.price.total_return_pct, dec!(50));
+    }
+
+    /// 2. 僅有現金股利：口徑 B 的現金累積正確，且口徑 A 的期末價值低於 B。
+    #[test]
+    fn test_cash_dividend_only() {
+        let events = [event(Some(date(2020, 7, 1)), dec!(5), None, Decimal::ZERO)];
+        let case = Case {
+            base_date: date(2020, 1, 2),
+            end_date: date(2021, 1, 2),
+            base_price: dec!(100),
+            end_price: dec!(100),
+            events: &events,
+        };
+        // 再投入查價回傳 None，讓口徑 C 也走現金累積，方便與 B 對照。
+        let result = run_with_price(&case, None).expect("應可計算");
+
+        // 100 股 × 5 元 = 500 元現金。
+        assert_eq!(result.total.cash_received, dec!(500));
+        assert_eq!(result.total.end_shares, dec!(100));
+        assert_eq!(result.total.end_value, dec!(10500));
+        // 口徑 A 忽略股利，期末價值必然較低。
+        assert_eq!(result.price.cash_received, Decimal::ZERO);
+        assert_eq!(result.price.end_value, dec!(10000));
+        assert!(result.price.end_value < result.total.end_value);
+        assert_eq!(result.dividend_events, 1);
+    }
+
+    /// 3. 僅有股票股利：股數增加為「原股數 ×(1 + 股票股利 / 10)」。
+    #[test]
+    fn test_stock_dividend_only() {
+        let events = [event(None, Decimal::ZERO, Some(date(2020, 7, 1)), dec!(1))];
+        let case = Case {
+            base_date: date(2020, 1, 2),
+            end_date: date(2021, 1, 2),
+            base_price: dec!(100),
+            end_price: dec!(100),
+            events: &events,
+        };
+        let result = run_with_price(&case, Some(dec!(90))).expect("應可計算");
+
+        // 100 股配股 1 元（配股率 0.1）→ 110 股。
+        assert_eq!(result.total.end_shares, dec!(110));
+        assert_eq!(result.reinvested.end_shares, dec!(110));
+        // 口徑 A 不理會配股，股數維持 100。
+        assert_eq!(result.price.end_shares, dec!(100));
+        assert!(result.price.end_shares < result.total.end_shares);
+        assert_eq!(result.total.cash_received, Decimal::ZERO);
+        assert_eq!(result.dividend_events, 1);
+    }
+
+    /// 4. 先配股、後配息：配息基數必須是「配股後」的股數。
+    ///
+    /// 若錯誤地把所有配息一次加總（以期初股數為基數），會得到 200 元現金；
+    /// 正確依時序套用應為 110 股 × 2 元 = 220 元。
+    #[test]
+    fn test_stock_then_cash_uses_post_split_shares() {
+        let events = [event(
+            Some(date(2020, 8, 1)),
+            dec!(2),
+            Some(date(2020, 7, 1)),
+            dec!(1),
+        )];
+        let case = Case {
+            base_date: date(2020, 1, 2),
+            end_date: date(2021, 1, 2),
+            base_price: dec!(100),
+            end_price: dec!(100),
+            events: &events,
+        };
+        let result = run_with_price(&case, None).expect("應可計算");
+
+        assert_eq!(result.total.end_shares, dec!(110));
+        // 關鍵斷言：220 而非 200。
+        assert_eq!(result.total.cash_received, dec!(220));
+        assert_eq!(result.total.end_value, dec!(11220));
+        // 同一筆事件雖產生兩個動作，僅計 1 次。
+        assert_eq!(result.dividend_events, 1);
+    }
+
+    /// 5. 先配息、後配股：與第 4 題對照，配息基數為期初股數。
+    #[test]
+    fn test_cash_then_stock_uses_pre_split_shares() {
+        let events = [event(
+            Some(date(2020, 7, 1)),
+            dec!(2),
+            Some(date(2020, 8, 1)),
+            dec!(1),
+        )];
+        let case = Case {
+            base_date: date(2020, 1, 2),
+            end_date: date(2021, 1, 2),
+            base_price: dec!(100),
+            end_price: dec!(100),
+            events: &events,
+        };
+        let result = run_with_price(&case, None).expect("應可計算");
+
+        assert_eq!(result.total.end_shares, dec!(110));
+        // 配息在配股之前 → 100 股 × 2 元 = 200 元。
+        assert_eq!(result.total.cash_received, dec!(200));
+        assert_eq!(result.total.end_value, dec!(11200));
+        assert_eq!(result.dividend_events, 1);
+    }
+
+    /// 6. 同一日同時除息與除權：約定先除息、後除權。
+    #[test]
+    fn test_same_day_cash_before_stock() {
+        let same_day = date(2020, 7, 1);
+        let events = [event(Some(same_day), dec!(2), Some(same_day), dec!(1))];
+        let case = Case {
+            base_date: date(2020, 1, 2),
+            end_date: date(2021, 1, 2),
+            base_price: dec!(100),
+            end_price: dec!(100),
+            events: &events,
+        };
+        let result = run_with_price(&case, None).expect("應可計算");
+
+        // 先除息（100 股 × 2 = 200）再除權（→ 110 股）。
+        assert_eq!(result.total.cash_received, dec!(200));
+        assert_eq!(result.total.end_shares, dec!(110));
+    }
+
+    /// 6b. 多筆事件、現金與股票除權息日交錯，驗證混合排序而非分兩迴圈。
+    #[test]
+    fn test_interleaved_dates_across_events() {
+        // 事件 A：除權 2020-03-01（配股 1 元）；除息 2020-09-01（現金 1 元）
+        // 事件 B：除息 2020-06-01（現金 1 元）；除權 2020-12-01（配股 1 元）
+        let events = [
+            event(
+                Some(date(2020, 9, 1)),
+                dec!(1),
+                Some(date(2020, 3, 1)),
+                dec!(1),
+            ),
+            event(
+                Some(date(2020, 6, 1)),
+                dec!(1),
+                Some(date(2020, 12, 1)),
+                dec!(1),
+            ),
+        ];
+        let case = Case {
+            base_date: date(2020, 1, 2),
+            end_date: date(2021, 1, 2),
+            base_price: dec!(100),
+            end_price: dec!(100),
+            events: &events,
+        };
+        let result = run_with_price(&case, None).expect("應可計算");
+
+        // 正確時序：03/01 配股 →110 股；06/01 配息 110 元；
+        // 09/01 配息 110 元；12/01 配股 →121 股。
+        assert_eq!(result.total.end_shares, dec!(121));
+        assert_eq!(result.total.cash_received, dec!(220));
+        assert_eq!(result.dividend_events, 2);
+    }
+
+    /// 7. 區間外的事件必須被排除：早於期初、等於期初、晚於期末皆不採計。
+    #[test]
+    fn test_events_outside_range_excluded() {
+        let base = date(2020, 1, 2);
+        let end = date(2021, 1, 2);
+        let events = [
+            // 早於期初。
+            event(Some(date(2019, 12, 1)), dec!(5), None, Decimal::ZERO),
+            // 等於期初（開區間，不採計）。
+            event(Some(base), dec!(5), None, Decimal::ZERO),
+            // 晚於期末。
+            event(Some(date(2021, 2, 1)), dec!(5), None, Decimal::ZERO),
+            // 等於期末（閉區間，採計）。
+            event(Some(end), dec!(3), None, Decimal::ZERO),
+        ];
+        let case = Case {
+            base_date: base,
+            end_date: end,
+            base_price: dec!(100),
+            end_price: dec!(100),
+            events: &events,
+        };
+        let result = run_with_price(&case, None).expect("應可計算");
+
+        // 只有期末當日那筆生效：100 股 × 3 元 = 300 元。
+        assert_eq!(result.total.cash_received, dec!(300));
+        assert_eq!(result.dividend_events, 1);
+    }
+
+    /// 8. 非法輸入一律回傳 `None`。
+    #[test]
+    fn test_invalid_inputs_return_none() {
+        let lookup = |_: NaiveDate| None;
+        let base = SimulationInput {
+            principal: dec!(10000),
+            base_date: date(2020, 1, 2),
+            end_date: date(2021, 1, 2),
+            base_price: dec!(100),
+            end_price: dec!(100),
+            events: &[],
+            reinvest_prices: &lookup,
+        };
+
+        // 期初價為零。
+        let mut tmp = base.clone();
+        tmp.base_price = Decimal::ZERO;
+        assert!(simulate(&tmp).is_none());
+
+        // 期末價為零。
+        let mut tmp1 = base.clone();
+        tmp1.end_price = Decimal::ZERO;
+        assert!(simulate(&tmp1).is_none());
+
+        // 期末日等於期初日。
+        let mut tmp2 = base.clone();
+        tmp2.end_date = tmp2.base_date;
+        assert!(simulate(&tmp2).is_none());
+
+        // 期末日早於期初日。
+        let mut tmp3 = base.clone();
+        tmp3.end_date = date(2019, 1, 2);
+        assert!(simulate(&tmp3).is_none());
+
+        // 投入金額非正數。
+        let mut tmp4 = base.clone();
+        tmp4.principal = Decimal::ZERO;
+        assert!(simulate(&tmp4).is_none());
+
+        // 負數價格。
+        let mut tmp5 = base;
+        tmp5.base_price = dec!(-1);
+        assert!(simulate(&tmp5).is_none());
+    }
+
+    /// 9. 再投入口徑查無除息日價格時，該次股利退回現金累積（不可遺失）。
+    #[test]
+    fn test_reinvest_falls_back_to_cash_when_price_missing() {
+        let with_price = date(2020, 4, 1);
+        let without_price = date(2020, 10, 1);
+        let events = [
+            event(Some(with_price), dec!(2), None, Decimal::ZERO),
+            event(Some(without_price), dec!(2), None, Decimal::ZERO),
+        ];
+        let lookup = move |d: NaiveDate| {
+            if d == with_price {
+                Some(dec!(50))
+            } else {
+                None
+            }
+        };
+        let input = SimulationInput {
+            principal: dec!(10000),
+            base_date: date(2020, 1, 2),
+            end_date: date(2021, 1, 2),
+            base_price: dec!(100),
+            end_price: dec!(100),
+            events: &events,
+            reinvest_prices: &lookup,
+        };
+        let result = simulate(&input).expect("應可計算");
+
+        // 第一次：100 股 × 2 = 200 元，以 50 元買回 4 股 → 104 股。
+        // 第二次：104 股 × 2 = 208 元，查無價格 → 累積現金。
+        assert_eq!(result.reinvested.end_shares, dec!(104));
+        assert_eq!(result.reinvested.cash_received, dec!(208));
+        assert_eq!(
+            result.reinvested.end_value,
+            dec!(104) * dec!(100) + dec!(208)
+        );
+        // 口徑 B 全數累積現金：200 + 200 = 400。
+        assert_eq!(result.total.cash_received, dec!(400));
+        assert_eq!(result.dividend_events, 2);
+    }
+
+    /// 10. 長期間（10 年、20 次除息）驗證 Decimal 累加不失真與年化正確性。
+    #[test]
+    fn test_long_horizon_precision() {
+        let base = date(2010, 1, 4);
+        // 刻意讓日數差恰為 3650 天，使 years 正好等於 10。
+        let end = base + Duration::days(3650);
+        let events: Vec<DividendEvent> = (1..=20)
+            .map(|i| {
+                event(
+                    Some(base + Duration::days(180 * i)),
+                    dec!(1),
+                    None,
+                    Decimal::ZERO,
+                )
+            })
+            .collect();
+        let case = Case {
+            base_date: base,
+            end_date: end,
+            base_price: dec!(100),
+            end_price: dec!(200),
+            events: &events,
+        };
+        let result = run_with_price(&case, None).expect("應可計算");
+
+        assert_eq!(result.years, dec!(10));
+        assert_eq!(result.dividend_events, 20);
+        // 100 股不變（無配股），每次配息 100 元 × 20 次 = 2,000 元，且完全不失真。
+        assert_eq!(result.total.end_shares, dec!(100));
+        assert_eq!(result.total.cash_received, dec!(2000));
+        assert_eq!(result.total.end_value, dec!(22000));
+        assert_eq!(result.total.total_return_pct, dec!(120));
+
+        // 手算年化：(22000 / 10000)^(1/10) - 1。
+        let expected = ((2.2_f64).powf(0.1) - 1.0) * 100.0;
+        let actual = result.total.cagr_pct.to_f64().expect("應可轉為 f64");
+        assert!(
+            (actual - expected).abs() < 1e-4,
+            "年化報酬 {actual} 與手算 {expected} 差距過大"
+        );
+    }
+
+    /// 11. `annualized_return_pct` 的邊界行為。
+    #[test]
+    fn test_annualized_return_pct_boundaries() {
+        // years = 1 時，年化報酬等於區間總報酬。
+        let cagr = annualized_return_pct(dec!(10000), dec!(12000), Decimal::ONE)
+            .expect("years = 1 應可計算");
+        let total = total_return_pct(dec!(10000), dec!(12000)).expect("應可計算");
+        assert!(
+            (cagr - total).abs() < dec!(0.0001),
+            "cagr={cagr} total={total}"
+        );
+
+        // 期末價值歸零 → -100%。
+        assert_eq!(
+            annualized_return_pct(dec!(10000), Decimal::ZERO, dec!(5)),
+            Some(dec!(-100))
+        );
+
+        // 非法輸入。
+        assert!(annualized_return_pct(Decimal::ZERO, dec!(100), dec!(1)).is_none());
+        assert!(annualized_return_pct(dec!(-1), dec!(100), dec!(1)).is_none());
+        assert!(annualized_return_pct(dec!(10000), dec!(100), Decimal::ZERO).is_none());
+        assert!(annualized_return_pct(dec!(10000), dec!(100), dec!(-1)).is_none());
+        assert!(annualized_return_pct(dec!(10000), dec!(-1), dec!(1)).is_none());
+
+        // 總報酬率的非法輸入。
+        assert!(total_return_pct(Decimal::ZERO, dec!(100)).is_none());
+        assert!(total_return_pct(dec!(-5), dec!(100)).is_none());
+        // 虧損情境。
+        assert_eq!(total_return_pct(dec!(10000), dec!(2500)), Some(dec!(-75)));
+    }
+
+    /// 12. 兩個除權息日皆為 `None`（`sort_key()` 為 `None`）的事件被安全略過。
+    #[test]
+    fn test_event_without_any_date_is_skipped() {
+        let events = [
+            event(None, dec!(5), None, dec!(1)),
+            event(Some(date(2020, 7, 1)), dec!(2), None, Decimal::ZERO),
+        ];
+        assert!(events[0].sort_key().is_none());
+
+        let case = Case {
+            base_date: date(2020, 1, 2),
+            end_date: date(2021, 1, 2),
+            base_price: dec!(100),
+            end_price: dec!(100),
+            events: &events,
+        };
+        let result = run_with_price(&case, None).expect("應可計算");
+
+        // 只有第二筆生效。
+        assert_eq!(result.total.cash_received, dec!(200));
+        assert_eq!(result.total.end_shares, dec!(100));
+        assert_eq!(result.dividend_events, 1);
+    }
+
+    /// 13. 金額為零的除權息（日期存在但金額為 0）不應被採計。
+    #[test]
+    fn test_zero_amount_event_not_counted() {
+        let events = [event(
+            Some(date(2020, 7, 1)),
+            Decimal::ZERO,
+            Some(date(2020, 7, 1)),
+            Decimal::ZERO,
+        )];
+        let case = Case {
+            base_date: date(2020, 1, 2),
+            end_date: date(2021, 1, 2),
+            base_price: dec!(100),
+            end_price: dec!(100),
+            events: &events,
+        };
+        let result = run_with_price(&case, None).expect("應可計算");
+
+        assert_eq!(result.dividend_events, 0);
+        assert_eq!(result.total.cash_received, Decimal::ZERO);
+        assert_eq!(result.total.end_shares, dec!(100));
+    }
 }

--- a/src/domain/performance/simulator.rs
+++ b/src/domain/performance/simulator.rs
@@ -1,0 +1,84 @@
+use chrono::NaiveDate;
+use rust_decimal::Decimal;
+
+use crate::domain::performance::entity::{DividendEvent, SimulationOutcome};
+
+/// 模擬所需的輸入。
+///
+/// 全部為值型別，不含任何 I/O —— 這讓整段報酬邏輯可以在沒有資料庫的情況下
+/// 被完整單元測試。本功能的正確性幾乎全繫於此。
+#[derive(Clone)]
+pub struct SimulationInput<'a> {
+    /// 期初投入金額（元）。
+    pub principal: Decimal,
+    /// 期初交易日。
+    pub base_date: NaiveDate,
+    /// 期末交易日。
+    pub end_date: NaiveDate,
+    /// 期初收盤價。必須大於零。
+    pub base_price: Decimal,
+    /// 期末收盤價。必須大於零。
+    pub end_price: Decimal,
+    /// 期間內的除權息事件。呼叫端不需預先排序。
+    pub events: &'a [DividendEvent],
+    /// 各除息日的收盤價，供「含息再投入」口徑買回股數之用。
+    ///
+    /// 查無該日價格時該次股利改為現金累積，不強制再投入。
+    pub reinvest_prices: &'a dyn Fn(NaiveDate) -> Option<Decimal>,
+}
+
+/// 三種口徑的模擬結果。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SimulationResult {
+    /// 口徑 A：純價格報酬。
+    pub price: SimulationOutcome,
+    /// 口徑 B：含息不再投入。
+    pub total: SimulationOutcome,
+    /// 口徑 C：含息再投入。
+    pub reinvested: SimulationOutcome,
+    /// 實際年數。
+    pub years: Decimal,
+    /// 期間內實際採計的除權息次數。
+    pub dividend_events: i32,
+}
+
+/// 依固定投入金額模擬三種口徑的期末價值與報酬率。
+///
+/// # 計算規則
+///
+/// - 期初以 `principal / base_price` 買入（允許小數股，純模擬不取整）。
+/// - 除權息事件<strong>必須依日期排序後逐筆套用</strong>：先配股再配息時，
+///   配息的基數是配股後的股數，無視時序一次加總會低估現金股利。
+/// - 配股率 = 每股股票股利 / 面額 10 元。
+/// - 事件生效條件為除權息日落在 `(base_date, end_date]` 區間內。
+///
+/// # Errors
+///
+/// `base_price` 或 `end_price` 非正數、或 `end_date <= base_date` 時回傳 `None`。
+pub fn simulate(input: &SimulationInput<'_>) -> Option<SimulationResult> {
+    // TODO(M1)：實作於 Agent A。
+    let _ = input;
+    unimplemented!("simulate 尚未實作")
+}
+
+/// 以期末價值與年數換算年化報酬率（%）。
+///
+/// `rust_decimal` 沒有通用實數次方運算，故此處刻意於最後一步轉為 `f64`
+/// 執行 `powf`，再轉回 `Decimal` 保留 4 位小數。金額與股數的累加全程維持
+/// `Decimal`，避免逐次運算累積浮點誤差 —— 只有這一步例外。
+pub fn annualized_return_pct(
+    principal: Decimal,
+    end_value: Decimal,
+    years: Decimal,
+) -> Option<Decimal> {
+    // TODO(M1)：實作於 Agent A。
+    let _ = (principal, end_value, years);
+    unimplemented!("annualized_return_pct 尚未實作")
+}
+
+/// 以期末價值換算區間總報酬率（%）。
+pub fn total_return_pct(principal: Decimal, end_value: Decimal) -> Option<Decimal> {
+    // TODO(M1)：實作於 Agent A。
+    let _ = (principal, end_value);
+    unimplemented!("total_return_pct 尚未實作")
+}

--- a/src/domain/performance/source.rs
+++ b/src/domain/performance/source.rs
@@ -1,0 +1,87 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::NaiveDate;
+use rust_decimal::Decimal;
+
+use crate::domain::performance::entity::DividendEvent;
+
+/// CAGR 計算所需的原始資料來源介面。
+///
+/// 與 [`crate::domain::performance::repository::CagrRepository`]（負責寫入與
+/// 查詢計算結果）分開，是因為兩者的職責完全不同：此介面只負責「把算之前需要
+/// 的原始資料一次撈齊」，全部是批次讀取，且刻意避免逐檔查詢 ——
+/// 全市場約 2,600 檔 × 8 個期間，任何 N+1 查詢都會讓排程無法收斂。
+#[async_trait]
+pub trait CagrSourceRepository: Send + Sync {
+    /// 取得不晚於指定日期的最近一個交易日。
+    ///
+    /// 用於把「執行日 − N 個月」的名目目標日對齊到實際有報價的交易日。
+    /// 資料庫中無任何早於該日的報價時回傳 `None`，代表該期間無法計算。
+    async fn fetch_trading_day_on_or_before(&self, date: NaiveDate) -> Result<Option<NaiveDate>>;
+
+    /// 取得最新一個交易日。
+    async fn fetch_latest_trading_day(&self) -> Result<Option<NaiveDate>>;
+
+    /// 取得計算母體：未下市的股票代號。
+    async fn fetch_active_symbols(&self) -> Result<Vec<String>>;
+
+    /// 取得每檔股票在報價資料中的最早日期。
+    ///
+    /// 這是判定「新上市／資料未涵蓋」的依據。專案的 `stocks` 表沒有上市日期
+    /// 欄位（ISIN 爬蟲雖有抓 `listing_date`，但在防腐層即被丟棄），因此改由
+    /// 報價資料推斷。注意 `DailyQuotes` 存在 `1970-01-01` 這類預設哨兵值，
+    /// 實作必須排除。
+    async fn fetch_first_quote_dates(&self) -> Result<Vec<(String, NaiveDate)>>;
+
+    /// 取得指定交易日全市場的收盤價（僅回傳大於零者）。
+    async fn fetch_closing_prices_on(&self, date: NaiveDate) -> Result<Vec<(String, Decimal)>>;
+
+    /// 取得每檔股票在指定日期區間內的第一筆報價（日期與收盤價）。
+    ///
+    /// 用於 2.4 的寬限規則：名目期初日當天無報價時，往後找寬限期內的第一筆。
+    async fn fetch_first_quote_within(
+        &self,
+        from: NaiveDate,
+        to: NaiveDate,
+    ) -> Result<Vec<(String, NaiveDate, Decimal)>>;
+
+    /// 取得指定日期之後所有股票的除權息事件。
+    ///
+    /// 實作必須處理兩件事，否則結果會系統性錯誤：
+    ///
+    /// 1. **年度彙總列與季度明細列去重**：`dividend` 表中同一
+    ///    `(security_code, year)` 可能同時存在 `quarter = ''` 的年度彙總列
+    ///    與 `Q1`–`Q4`／`H1`–`H2` 明細列（2026-08-07 實測有 1,619 組），
+    ///    無條件加總會讓季配息股的股利被計算兩次。規則是「有明細就只用明細，
+    ///    沒明細才用年度彙總列」。
+    /// 2. **除權息日的髒值**：欄位型別是 `varchar(10)`，實測含 `'-'`
+    ///    （17,553 筆）、`'尚未公布'`、空字串，甚至有 `'1.39%'` 這類百分比
+    ///    字串。**絕不可在 SQL 中做 `::date` 轉型**，必須取出原始字串後在
+    ///    Rust 端解析，解析失敗者視為該日期不存在（`None`）。
+    async fn fetch_dividend_events_since(&self, since: NaiveDate) -> Result<Vec<DividendEvent>>;
+
+    /// 批次取得指定 (股票代號, 日期) 組合的收盤價。
+    ///
+    /// 供「含息再投入」口徑在除息日買回股數之用。刻意設計成批次介面：
+    /// 十年份的除權息事件約有數萬筆，逐筆查詢會產生數萬次往返。
+    async fn fetch_closing_prices_at(
+        &self,
+        pairs: &[(String, NaiveDate)],
+    ) -> Result<Vec<(String, NaiveDate, Decimal)>>;
+
+    /// 找出指定期間內疑似減資或分割的「事件」，回傳 (股票代號, 發生日)。
+    ///
+    /// 本專案沒有記錄減資與股票分割，只能從價格序列反推：單日收盤價出現無法用
+    /// 除權息解釋的大幅跳動。期間拉長到五年、十年時，遇上這類未建模事件幾乎是
+    /// 必然，沒有這道防護，長期間排行榜的頭尾兩端都不可信。
+    ///
+    /// **刻意回傳帶日期的事件而非股票清單**：呼叫端要為八個期間各自判定，
+    /// 若只回傳代號，就只能用最長期間算一次再套用到所有期間 —— 那會讓 2017 年
+    /// 的減資把 3 個月期間的結果也標記為異常，語義完全錯誤。回傳事件讓呼叫端
+    /// 用單次查詢的結果依日期切分到各期間。
+    async fn fetch_anomaly_events(
+        &self,
+        from: NaiveDate,
+        to: NaiveDate,
+    ) -> Result<Vec<(String, NaiveDate)>>;
+}

--- a/src/infra/database/repository/cagr_source.rs
+++ b/src/infra/database/repository/cagr_source.rs
@@ -360,6 +360,375 @@ fn parse_ex_dividend_date(raw: &str) -> Option<NaiveDate> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rust_decimal_macros::dec;
+
+    /// 測試專用的假代號；真實市場不存在此代號。
+    const FAKE_A: &str = "79979S1";
+    /// 已下市的假代號，用於驗證母體排除規則。
+    const FAKE_B: &str = "79979S2";
+
+    /// 測試資料一律落在 1990 年初 —— 遠早於 `DailyQuotes` 實際涵蓋的 2012 年，
+    /// 既不會與正式資料互相干擾，也仍在哨兵值 `1990-01-01` 之後。
+    fn day(d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(1990, 1, d).expect("測試日期應合法")
+    }
+
+    async fn cleanup() {
+        let symbols = vec![FAKE_A.to_string(), FAKE_B.to_string()];
+        let _ = sqlx::query(r#"DELETE FROM "DailyQuotes" WHERE stock_symbol = ANY($1)"#)
+            .bind(&symbols)
+            .execute(database::get_connection())
+            .await;
+        let _ = sqlx::query("DELETE FROM dividend WHERE security_code = ANY($1)")
+            .bind(&symbols)
+            .execute(database::get_connection())
+            .await;
+        let _ = sqlx::query("DELETE FROM stocks WHERE stock_symbol = ANY($1)")
+            .bind(&symbols)
+            .execute(database::get_connection())
+            .await;
+    }
+
+    async fn insert_quote(symbol: &str, date: NaiveDate, close: Decimal) {
+        sqlx::query(
+            r#"INSERT INTO "DailyQuotes" ("Date", stock_symbol, "ClosingPrice") VALUES ($1, $2, $3)"#,
+        )
+        .bind(date)
+        .bind(symbol)
+        .bind(close)
+        .execute(database::get_connection())
+        .await
+        .expect("插入報價");
+    }
+
+    async fn insert_stock(symbol: &str, suspend: bool) {
+        sqlx::query(
+            r#"INSERT INTO stocks ("SecurityCode", "Name", stock_symbol, "SuspendListing")
+               VALUES ($1, $1, $1, $2)
+               ON CONFLICT (stock_symbol) DO UPDATE SET "SuspendListing" = excluded."SuspendListing""#,
+        )
+        .bind(symbol)
+        .bind(suspend)
+        .execute(database::get_connection())
+        .await
+        .expect("插入股票母檔");
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_dividend(
+        symbol: &str,
+        year: i32,
+        quarter: &str,
+        cash: Decimal,
+        stock: Decimal,
+        date1: &str,
+        date2: &str,
+    ) {
+        sqlx::query(
+            r#"INSERT INTO dividend (security_code, year, quarter, cash_dividend, stock_dividend,
+                                     "ex-dividend_date1", "ex-dividend_date2")
+               VALUES ($1, $2, $3, $4, $5, $6, $7)
+               ON CONFLICT (security_code, year, quarter) DO UPDATE
+                   SET cash_dividend = excluded.cash_dividend"#,
+        )
+        .bind(symbol)
+        .bind(year)
+        .bind(quarter)
+        .bind(cash)
+        .bind(stock)
+        .bind(date1)
+        .bind(date2)
+        .execute(database::get_connection())
+        .await
+        .expect("插入股利");
+    }
+
+    /// 建立測試資料集。
+    ///
+    /// `79979S1` 的價格序列刻意安排兩次大跳動：01-03 那次有對應的除息日
+    /// （不得標記為異常），01-05 那次沒有（必須標記）。
+    async fn seed() {
+        cleanup().await;
+
+        insert_stock(FAKE_A, false).await;
+        insert_stock(FAKE_B, true).await;
+
+        // 1970-01-01 是資料庫中實際存在的預設哨兵值，必須被所有查詢排除。
+        insert_quote(
+            FAKE_A,
+            NaiveDate::from_ymd_opt(1970, 1, 1).unwrap(),
+            dec!(1),
+        )
+        .await;
+        insert_quote(FAKE_A, day(2), dec!(100)).await;
+        insert_quote(FAKE_A, day(3), dec!(160)).await;
+        // 收盤價為零者視同無報價。
+        insert_quote(FAKE_A, day(4), Decimal::ZERO).await;
+        insert_quote(FAKE_A, day(5), dec!(300)).await;
+        insert_quote(FAKE_A, day(8), dec!(310)).await;
+        insert_quote(FAKE_B, day(3), dec!(50)).await;
+
+        // 年度彙總列與同年季度明細列並存：只能採計明細，否則股利算兩次。
+        insert_dividend(FAKE_A, 1990, "", dec!(5), Decimal::ZERO, "1990-01-03", "-").await;
+        insert_dividend(
+            FAKE_A,
+            1990,
+            "Q1",
+            dec!(2),
+            Decimal::ZERO,
+            "1990-01-03",
+            "-",
+        )
+        .await;
+        // 除息日為髒值、除權日合法：仍應取得事件，但現金除息日為 None。
+        insert_dividend(FAKE_A, 1991, "", dec!(3), dec!(1), "1.39%", "1991-03-01").await;
+        // 兩個日期都是髒值 —— 無法定位於時間軸，必須整筆略過。
+        insert_dividend(FAKE_B, 1990, "", dec!(1), Decimal::ZERO, "尚未公布", "-").await;
+    }
+
+    #[tokio::test]
+    #[cfg_attr(
+        not(feature = "integration-tests"),
+        ignore = "需要外部服務（PostgreSQL/Redis），請加 --features integration-tests 執行"
+    )]
+    async fn test_trading_day_and_symbol_queries() {
+        dotenvy::dotenv().ok();
+        if database::ping().await.is_err() {
+            println!("跳過 test_trading_day_and_symbol_queries：無資料庫連接");
+            return;
+        }
+        seed().await;
+        let repo = PgCagrSourceRepository::new();
+
+        // 對齊到不晚於指定日的交易日；1990-01-04 收盤價為零但仍是交易日。
+        assert_eq!(
+            repo.fetch_trading_day_on_or_before(day(7))
+                .await
+                .expect("fetch_trading_day_on_or_before"),
+            Some(day(5))
+        );
+        assert_eq!(
+            repo.fetch_trading_day_on_or_before(day(3))
+                .await
+                .expect("fetch_trading_day_on_or_before"),
+            Some(day(3))
+        );
+        // 哨兵值 1970-01-01 不得被當成交易日。
+        assert_eq!(
+            repo.fetch_trading_day_on_or_before(NaiveDate::from_ymd_opt(1989, 12, 31).unwrap())
+                .await
+                .expect("fetch_trading_day_on_or_before"),
+            None
+        );
+
+        let latest = repo
+            .fetch_latest_trading_day()
+            .await
+            .expect("fetch_latest_trading_day");
+        assert!(latest.is_some_and(|d| d >= day(8)));
+
+        let symbols = repo
+            .fetch_active_symbols()
+            .await
+            .expect("fetch_active_symbols");
+        assert!(symbols.iter().any(|s| s == FAKE_A));
+        assert!(
+            !symbols.iter().any(|s| s == FAKE_B),
+            "已下市股票不得進入計算母體"
+        );
+
+        let first_quotes = repo
+            .fetch_first_quote_dates()
+            .await
+            .expect("fetch_first_quote_dates");
+        let first = first_quotes
+            .iter()
+            .find(|(symbol, _)| symbol == FAKE_A)
+            .map(|(_, date)| *date);
+        assert_eq!(first, Some(day(2)), "哨兵值 1970-01-01 必須被排除");
+
+        cleanup().await;
+    }
+
+    #[tokio::test]
+    #[cfg_attr(
+        not(feature = "integration-tests"),
+        ignore = "需要外部服務（PostgreSQL/Redis），請加 --features integration-tests 執行"
+    )]
+    async fn test_price_queries_skip_zero_and_respect_ranges() {
+        dotenvy::dotenv().ok();
+        if database::ping().await.is_err() {
+            println!("跳過 test_price_queries_skip_zero_and_respect_ranges：無資料庫連接");
+            return;
+        }
+        seed().await;
+        let repo = PgCagrSourceRepository::new();
+
+        let prices = repo
+            .fetch_closing_prices_on(day(3))
+            .await
+            .expect("fetch_closing_prices_on");
+        assert_eq!(
+            prices
+                .iter()
+                .find(|(symbol, _)| symbol == FAKE_A)
+                .map(|(_, price)| *price),
+            Some(dec!(160))
+        );
+
+        // 收盤價為零者不得出現。
+        let zero_day = repo
+            .fetch_closing_prices_on(day(4))
+            .await
+            .expect("fetch_closing_prices_on");
+        assert!(!zero_day.iter().any(|(symbol, _)| symbol == FAKE_A));
+
+        // 寬限查詢的區間是左開右閉：期初日當天的報價不算，往後第一筆才算。
+        let grace = repo
+            .fetch_first_quote_within(day(2), day(6))
+            .await
+            .expect("fetch_first_quote_within");
+        let hit = grace.iter().find(|(symbol, _, _)| symbol == FAKE_A);
+        assert_eq!(
+            hit.map(|(_, date, price)| (*date, *price)),
+            Some((day(3), dec!(160)))
+        );
+
+        // 批次查價：命中者回傳，查無者靜默略過（不得整批失敗）。
+        let pairs = vec![
+            (FAKE_A.to_string(), day(5)),
+            (FAKE_A.to_string(), day(6)),
+            (FAKE_A.to_string(), day(4)),
+        ];
+        let at = repo
+            .fetch_closing_prices_at(&pairs)
+            .await
+            .expect("fetch_closing_prices_at");
+        assert_eq!(at.len(), 1);
+        assert_eq!(at[0], (FAKE_A.to_string(), day(5), dec!(300)));
+
+        // 空輸入不應送出查詢。
+        assert!(
+            repo.fetch_closing_prices_at(&[])
+                .await
+                .expect("fetch_closing_prices_at empty")
+                .is_empty()
+        );
+
+        cleanup().await;
+    }
+
+    #[tokio::test]
+    #[cfg_attr(
+        not(feature = "integration-tests"),
+        ignore = "需要外部服務（PostgreSQL/Redis），請加 --features integration-tests 執行"
+    )]
+    async fn test_dividend_events_deduplicate_and_tolerate_dirty_dates() {
+        dotenvy::dotenv().ok();
+        if database::ping().await.is_err() {
+            println!(
+                "跳過 test_dividend_events_deduplicate_and_tolerate_dirty_dates：無資料庫連接"
+            );
+            return;
+        }
+        seed().await;
+        let repo = PgCagrSourceRepository::new();
+
+        let events = repo
+            .fetch_dividend_events_since(day(1))
+            .await
+            .expect("fetch_dividend_events_since");
+        let mine: Vec<&DividendEvent> = events
+            .iter()
+            .filter(|event| event.stock_symbol == FAKE_A || event.stock_symbol == FAKE_B)
+            .collect();
+
+        // 1990 年只能取到季度明細（現金 2），年度彙總列（現金 5）必須被去重掉，
+        // 否則季配息股的股利會被計算兩次。
+        let nineteen_ninety: Vec<&&DividendEvent> = mine
+            .iter()
+            .filter(|event| event.ex_dividend_date_cash == Some(day(3)))
+            .collect();
+        assert_eq!(nineteen_ninety.len(), 1, "年度彙總列與明細列不得同時採計");
+        assert_eq!(nineteen_ninety[0].cash_dividend, dec!(2));
+
+        // 除息日是 '1.39%' 這種髒值時只丟棄該日期，事件本身仍憑除權日成立。
+        let dirty = mine
+            .iter()
+            .find(|event| event.ex_dividend_date_stock.is_some())
+            .expect("應取得只有除權日的事件");
+        assert_eq!(dirty.ex_dividend_date_cash, None);
+        assert_eq!(
+            dirty.ex_dividend_date_stock,
+            NaiveDate::from_ymd_opt(1991, 3, 1)
+        );
+
+        // 兩個日期都是髒值的事件無法定位，整筆略過。
+        assert!(
+            !mine.iter().any(|event| event.stock_symbol == FAKE_B),
+            "沒有任何可解析日期的事件不得回傳"
+        );
+
+        // since 之後才生效：1991 的事件仍在，1990 的已被濾掉。
+        let later = repo
+            .fetch_dividend_events_since(NaiveDate::from_ymd_opt(1991, 1, 1).unwrap())
+            .await
+            .expect("fetch_dividend_events_since later");
+        let later_mine: Vec<&DividendEvent> = later
+            .iter()
+            .filter(|event| event.stock_symbol == FAKE_A)
+            .collect();
+        assert_eq!(later_mine.len(), 1);
+        assert_eq!(later_mine[0].stock_dividend, dec!(1));
+
+        cleanup().await;
+    }
+
+    #[tokio::test]
+    #[cfg_attr(
+        not(feature = "integration-tests"),
+        ignore = "需要外部服務（PostgreSQL/Redis），請加 --features integration-tests 執行"
+    )]
+    async fn test_anomaly_detection_ignores_jumps_explained_by_dividends() {
+        dotenvy::dotenv().ok();
+        if database::ping().await.is_err() {
+            println!(
+                "跳過 test_anomaly_detection_ignores_jumps_explained_by_dividends：無資料庫連接"
+            );
+            return;
+        }
+        seed().await;
+        let repo = PgCagrSourceRepository::new();
+
+        let events = repo
+            .fetch_anomaly_events(day(2), day(8))
+            .await
+            .expect("fetch_anomaly_events");
+        let mine: Vec<NaiveDate> = events
+            .iter()
+            .filter(|(symbol, _)| symbol == FAKE_A)
+            .map(|(_, date)| *date)
+            .collect();
+
+        // 01-03 跳 60% 但當天有登錄除息日 → 可解釋，不標記；
+        // 01-05 跳 87.5% 且無對應除權息 → 標記；
+        // 01-08 僅跳 3.3%，未達 30% 門檻。
+        assert_eq!(mine, vec![day(5)]);
+
+        // 事件帶日期回傳，呼叫端才能依期間各自判定：縮小區間後該事件應消失。
+        let narrowed = repo
+            .fetch_anomaly_events(day(5), day(8))
+            .await
+            .expect("fetch_anomaly_events narrowed");
+        assert!(
+            !narrowed
+                .iter()
+                .any(|(symbol, date)| symbol == FAKE_A && *date == day(5)),
+            "區間起點之後才計算跳動，起點當天不應再被標記"
+        );
+
+        cleanup().await;
+    }
 
     /// 驗證髒值一律回傳 `None`，合法日期正常解析。
     #[test]

--- a/src/infra/database/repository/cagr_source.rs
+++ b/src/infra/database/repository/cagr_source.rs
@@ -1,0 +1,383 @@
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use chrono::NaiveDate;
+use rust_decimal::Decimal;
+use sqlx::Row;
+
+use crate::domain::performance::{DividendEvent, source::CagrSourceRepository};
+use crate::infra::database;
+
+/// `DailyQuotes."Date"` 的預設哨兵值下界。
+///
+/// 該欄位在部分資料列留有 `1970-01-01` 這類預設值（非真實交易日），
+/// 若不排除，「最早報價日」與「涵蓋年數」都會被嚴重扭曲。
+const SENTINEL_DATE_FLOOR: &str = "1990-01-01";
+
+/// 判定疑似減資／分割的單日跳動門檻。
+///
+/// 台股漲跌幅限制為 ±10%，直覺上超過 11% 就該視為異常，但 2026-08-07 以近十年
+/// 實際資料校準的結果顯示這個門檻完全不堪用 —— 會標記到全市場 45% 的股票，
+/// 等於沒有標記。誤判來源主要有三類：興櫃與追蹤外國指數的 ETF／ETN 本就沒有
+/// 漲跌幅限制、新上市初期不受限、以及**除息日未登錄**（`dividend` 表有 17,553
+/// 筆除息日是 `'-'`，這些除權息造成的跳空無法被排除）。
+///
+/// 實測跳動幅度分布（十年、已排除可比對到的除權息日）：
+///
+/// | 幅度 | 檔數 |
+/// |------|------|
+/// | 11–20% | 1,113 |
+/// | 20–30% | 412 |
+/// | 30% 以上 | 553 |
+///
+/// 改採 30%：減資彌補虧損五成會讓參考價翻倍、減資三成約跳 43%，都遠在此門檻
+/// 之上；而 11–20% 那一大段主要是上述誤判來源。
+///
+/// **已知限制**：小幅現金減資（例如減資一成，股價僅上調約 11%）不會被偵測到。
+/// 這是刻意的取捨 —— 那種幅度對 CAGR 的扭曲本來就小，而為了抓它把門檻降下來，
+/// 會讓旗標因為誤判太多而被使用者完全忽略。
+const ANOMALY_JUMP_THRESHOLD: &str = "0.30";
+
+/// CAGR 原始資料來源之 PostgreSQL 實作。
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PgCagrSourceRepository;
+
+impl PgCagrSourceRepository {
+    /// 建立實例。
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl CagrSourceRepository for PgCagrSourceRepository {
+    async fn fetch_trading_day_on_or_before(&self, date: NaiveDate) -> Result<Option<NaiveDate>> {
+        let sql = r#"
+            SELECT MAX("Date") AS trading_day
+            FROM "DailyQuotes"
+            WHERE "Date" <= $1 AND "Date" > $2::date
+        "#;
+
+        let row = sqlx::query(sql)
+            .bind(date)
+            .bind(SENTINEL_DATE_FLOOR)
+            .fetch_one(database::get_connection())
+            .await
+            .context("Failed to fetch trading day on or before the given date")?;
+
+        Ok(row.try_get::<Option<NaiveDate>, _>("trading_day")?)
+    }
+
+    async fn fetch_latest_trading_day(&self) -> Result<Option<NaiveDate>> {
+        let sql = r#"
+            SELECT MAX("Date") AS trading_day
+            FROM "DailyQuotes"
+            WHERE "Date" > $1::date
+        "#;
+
+        let row = sqlx::query(sql)
+            .bind(SENTINEL_DATE_FLOOR)
+            .fetch_one(database::get_connection())
+            .await
+            .context("Failed to fetch the latest trading day")?;
+
+        Ok(row.try_get::<Option<NaiveDate>, _>("trading_day")?)
+    }
+
+    async fn fetch_active_symbols(&self) -> Result<Vec<String>> {
+        let sql = r#"
+            SELECT stock_symbol
+            FROM stocks
+            WHERE "SuspendListing" = false
+            ORDER BY stock_symbol
+        "#;
+
+        let rows = sqlx::query(sql)
+            .fetch_all(database::get_connection())
+            .await
+            .context("Failed to fetch active symbols")?;
+
+        rows.into_iter()
+            .map(|row| Ok(row.try_get::<String, _>("stock_symbol")?))
+            .collect()
+    }
+
+    async fn fetch_first_quote_dates(&self) -> Result<Vec<(String, NaiveDate)>> {
+        let sql = r#"
+            SELECT stock_symbol, MIN("Date") AS first_date
+            FROM "DailyQuotes"
+            WHERE "Date" > $1::date AND "ClosingPrice" > 0
+            GROUP BY stock_symbol
+        "#;
+
+        let rows = sqlx::query(sql)
+            .bind(SENTINEL_DATE_FLOOR)
+            .fetch_all(database::get_connection())
+            .await
+            .context("Failed to fetch first quote dates")?;
+
+        rows.into_iter()
+            .map(|row| {
+                Ok((
+                    row.try_get::<String, _>("stock_symbol")?,
+                    row.try_get::<NaiveDate, _>("first_date")?,
+                ))
+            })
+            .collect()
+    }
+
+    async fn fetch_closing_prices_on(&self, date: NaiveDate) -> Result<Vec<(String, Decimal)>> {
+        let sql = r#"
+            SELECT stock_symbol, "ClosingPrice"
+            FROM "DailyQuotes"
+            WHERE "Date" = $1 AND "ClosingPrice" > 0
+        "#;
+
+        let rows = sqlx::query(sql)
+            .bind(date)
+            .fetch_all(database::get_connection())
+            .await
+            .context("Failed to fetch closing prices on the given date")?;
+
+        rows.into_iter()
+            .map(|row| {
+                Ok((
+                    row.try_get::<String, _>("stock_symbol")?,
+                    row.try_get::<Decimal, _>("ClosingPrice")?,
+                ))
+            })
+            .collect()
+    }
+
+    async fn fetch_first_quote_within(
+        &self,
+        from: NaiveDate,
+        to: NaiveDate,
+    ) -> Result<Vec<(String, NaiveDate, Decimal)>> {
+        // 區間刻意為左開右閉：`from`（統一對齊後的期初交易日）當天有報價的
+        // 股票走一般路徑，這裡只處理當天沒有報價、需要套用寬限規則者。
+        let sql = r#"
+            SELECT DISTINCT ON (stock_symbol)
+                   stock_symbol, "Date", "ClosingPrice"
+            FROM "DailyQuotes"
+            WHERE "Date" > $1 AND "Date" <= $2 AND "ClosingPrice" > 0
+            ORDER BY stock_symbol, "Date"
+        "#;
+
+        let rows = sqlx::query(sql)
+            .bind(from)
+            .bind(to)
+            .fetch_all(database::get_connection())
+            .await
+            .context("Failed to fetch first quote within the grace period")?;
+
+        rows.into_iter()
+            .map(|row| {
+                Ok((
+                    row.try_get::<String, _>("stock_symbol")?,
+                    row.try_get::<NaiveDate, _>("Date")?,
+                    row.try_get::<Decimal, _>("ClosingPrice")?,
+                ))
+            })
+            .collect()
+    }
+
+    async fn fetch_dividend_events_since(&self, since: NaiveDate) -> Result<Vec<DividendEvent>> {
+        // 兩個必要的防護，缺一結果就會系統性錯誤：
+        //
+        // 1. `has_detail` 去重：同一 (security_code, year) 可能同時存在
+        //    `quarter = ''` 的年度彙總列與季度明細列（2026-08-07 實測 1,619
+        //    組）。年度列是由明細聚合產生的，一起加總會讓季配息股算兩次。
+        // 2. 除權息日欄位是 varchar 且含髒值（`'-'`、`'尚未公布'`，實測甚至
+        //    有 `'1.39%'` 這種百分比字串）。這裡只用正則過濾掉明顯不合格式
+        //    者以減少傳輸量，**絕不做 `::date` 轉型**——PostgreSQL 不保證
+        //    WHERE 與 SELECT 的求值順序，轉型仍可能碰到髒值而整批失敗。
+        //    真正的解析在 Rust 端進行，失敗者視為該日期不存在。
+        let sql = r#"
+            WITH has_detail AS (
+                SELECT security_code, year
+                FROM dividend
+                WHERE quarter <> ''
+                GROUP BY security_code, year
+            )
+            SELECT d.security_code,
+                   d."ex-dividend_date1",
+                   d."ex-dividend_date2",
+                   d.cash_dividend,
+                   d.stock_dividend
+            FROM dividend d
+            LEFT JOIN has_detail hd
+                   ON hd.security_code = d.security_code AND hd.year = d.year
+            WHERE (d.quarter <> '' OR hd.year IS NULL)
+              AND (d.cash_dividend > 0 OR d.stock_dividend > 0)
+              AND (
+                    (d."ex-dividend_date1" ~ '^\d{4}-\d{2}-\d{2}$' AND d."ex-dividend_date1" >= $1)
+                 OR (d."ex-dividend_date2" ~ '^\d{4}-\d{2}-\d{2}$' AND d."ex-dividend_date2" >= $1)
+              )
+        "#;
+
+        let rows = sqlx::query(sql)
+            .bind(since.format("%Y-%m-%d").to_string())
+            .fetch_all(database::get_connection())
+            .await
+            .context("Failed to fetch dividend events")?;
+
+        let mut events = Vec::with_capacity(rows.len());
+        for row in rows {
+            let event = DividendEvent {
+                stock_symbol: row.try_get::<String, _>("security_code")?,
+                ex_dividend_date_cash: parse_ex_dividend_date(
+                    &row.try_get::<String, _>("ex-dividend_date1")?,
+                ),
+                ex_dividend_date_stock: parse_ex_dividend_date(
+                    &row.try_get::<String, _>("ex-dividend_date2")?,
+                ),
+                cash_dividend: row.try_get::<Decimal, _>("cash_dividend")?,
+                stock_dividend: row.try_get::<Decimal, _>("stock_dividend")?,
+            };
+
+            // 兩個日期都解析失敗的事件無法定位於時間軸上，直接略過。
+            if event.sort_key().is_some() {
+                events.push(event);
+            }
+        }
+
+        Ok(events)
+    }
+
+    async fn fetch_closing_prices_at(
+        &self,
+        pairs: &[(String, NaiveDate)],
+    ) -> Result<Vec<(String, NaiveDate, Decimal)>> {
+        if pairs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // 以 UNNEST 把數萬筆 (代號, 日期) 組合一次送進資料庫，
+        // 比逐筆查詢少掉數萬次往返；JOIN 走 stock_symbol + Date 唯一索引。
+        let symbols: Vec<String> = pairs.iter().map(|(symbol, _)| symbol.clone()).collect();
+        let dates: Vec<NaiveDate> = pairs.iter().map(|(_, date)| *date).collect();
+
+        let sql = r#"
+            SELECT dq.stock_symbol, dq."Date", dq."ClosingPrice"
+            FROM UNNEST($1::varchar[], $2::date[]) AS wanted(stock_symbol, quote_date)
+            JOIN "DailyQuotes" dq
+              ON dq.stock_symbol = wanted.stock_symbol
+             AND dq."Date" = wanted.quote_date
+            WHERE dq."ClosingPrice" > 0
+        "#;
+
+        let rows = sqlx::query(sql)
+            .bind(&symbols)
+            .bind(&dates)
+            .fetch_all(database::get_connection())
+            .await
+            .context("Failed to fetch closing prices for the given symbol/date pairs")?;
+
+        rows.into_iter()
+            .map(|row| {
+                Ok((
+                    row.try_get::<String, _>("stock_symbol")?,
+                    row.try_get::<NaiveDate, _>("Date")?,
+                    row.try_get::<Decimal, _>("ClosingPrice")?,
+                ))
+            })
+            .collect()
+    }
+
+    async fn fetch_anomaly_events(
+        &self,
+        from: NaiveDate,
+        to: NaiveDate,
+    ) -> Result<Vec<(String, NaiveDate)>> {
+        // 本專案沒有記錄減資與股票分割，只能從價格序列反推：單日跳動超過
+        // [`ANOMALY_JUMP_THRESHOLD`]、且當天沒有對應的除權息事件，即視為疑似異常。
+        //
+        // 回傳帶日期的事件（而非去重後的代號），呼叫端才能把單次查詢的結果依日期
+        // 切分到八個期間各自判定。
+        //
+        // 比對除權息日時刻意用 `to_char(...)` 把日期轉成字串去比對 varchar 欄位，
+        // 而不是把 varchar 轉成 date —— 後者會在髒值上整批失敗。
+        let sql = r#"
+            WITH px AS (
+                SELECT stock_symbol,
+                       "Date",
+                       "ClosingPrice",
+                       LAG("ClosingPrice") OVER (
+                           PARTITION BY stock_symbol ORDER BY "Date"
+                       ) AS prev_price
+                FROM "DailyQuotes"
+                WHERE "Date" BETWEEN $1 AND $2 AND "ClosingPrice" > 0
+            ),
+            jumps AS (
+                SELECT stock_symbol, "Date"
+                FROM px
+                WHERE prev_price IS NOT NULL
+                  AND prev_price > 0
+                  AND ABS("ClosingPrice" / prev_price - 1) > $3::numeric
+            )
+            SELECT j.stock_symbol, j."Date"
+            FROM jumps j
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM dividend d
+                WHERE d.security_code = j.stock_symbol
+                  AND (
+                        d."ex-dividend_date1" = to_char(j."Date", 'YYYY-MM-DD')
+                     OR d."ex-dividend_date2" = to_char(j."Date", 'YYYY-MM-DD')
+                  )
+            )
+        "#;
+
+        let rows = sqlx::query(sql)
+            .bind(from)
+            .bind(to)
+            .bind(ANOMALY_JUMP_THRESHOLD)
+            .fetch_all(database::get_connection())
+            .await
+            .context("Failed to detect anomaly events")?;
+
+        rows.into_iter()
+            .map(|row| {
+                Ok((
+                    row.try_get::<String, _>("stock_symbol")?,
+                    row.try_get::<NaiveDate, _>("Date")?,
+                ))
+            })
+            .collect()
+    }
+}
+
+/// 解析除權息日字串。
+///
+/// 欄位型別為 `varchar(10)`，實務值除了 `YYYY-MM-DD` 之外還包含 `'-'`、
+/// `'尚未公布'`、空字串，甚至 `'1.39%'` 這類明顯放錯欄位的百分比字串。
+/// 一律以「解析失敗即視為沒有這個日期」處理，與 domain 層
+/// `Dividend::is_eligible_for_date` 的既有語義一致。
+fn parse_ex_dividend_date(raw: &str) -> Option<NaiveDate> {
+    NaiveDate::parse_from_str(raw.trim(), "%Y-%m-%d").ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 驗證髒值一律回傳 `None`，合法日期正常解析。
+    #[test]
+    fn test_parse_ex_dividend_date() {
+        assert_eq!(
+            parse_ex_dividend_date("2024-07-11"),
+            NaiveDate::from_ymd_opt(2024, 7, 11)
+        );
+        assert_eq!(
+            parse_ex_dividend_date(" 2024-07-11 "),
+            NaiveDate::from_ymd_opt(2024, 7, 11)
+        );
+
+        // 以下皆為資料庫中實際出現過的髒值。
+        assert_eq!(parse_ex_dividend_date("-"), None);
+        assert_eq!(parse_ex_dividend_date("尚未公布"), None);
+        assert_eq!(parse_ex_dividend_date(""), None);
+        assert_eq!(parse_ex_dividend_date("1.39%"), None);
+        assert_eq!(parse_ex_dividend_date("2024/07/11"), None);
+    }
+}

--- a/src/infra/database/repository/mod.rs
+++ b/src/infra/database/repository/mod.rs
@@ -1,11 +1,13 @@
 use crate::infra::nosql::redis::RedisError;
 use thiserror::Error;
 
+pub mod cagr_source;
 pub mod config;
 pub mod dividend;
 pub mod financial;
 pub mod market_index;
 pub mod money_flow;
+pub mod performance;
 pub mod portfolio;
 pub mod quote;
 pub mod stock;

--- a/src/infra/database/repository/performance.rs
+++ b/src/infra/database/repository/performance.rs
@@ -532,6 +532,31 @@ WHERE date = $1 AND period = $2
         Ok(row.0)
     }
 
+    async fn fetch_dates_missing_period(&self, period: CagrPeriod) -> Result<Vec<NaiveDate>> {
+        // 以 NOT EXISTS 而非 LEFT JOIN：只要該日期出現過任何一列指定期間的
+        // 結果就算已回填，不需要逐檔比對母體。
+        let sql = r#"
+            SELECT DISTINCT s.date
+            FROM stock_cagr s
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM stock_cagr t
+                WHERE t.date = s.date AND t.period = $1
+            )
+            ORDER BY s.date
+        "#;
+
+        let rows: Vec<(NaiveDate,)> = sqlx::query_as(sql)
+            .bind(period.code())
+            .fetch_all(database::get_connection())
+            .await
+            .context(
+                "Failed to fetch dates missing period in PgCagrRepository::fetch_dates_missing_period",
+            )?;
+
+        Ok(rows.into_iter().map(|(date,)| date).collect())
+    }
+
     /// 刪除早於指定日期的歷史資料。
     async fn delete_before(&self, date: NaiveDate) -> Result<u64> {
         let result = sqlx::query("DELETE FROM stock_cagr WHERE date < $1")
@@ -890,6 +915,49 @@ mod tests {
         // 最新基準日必定不早於測試用的 1990-01-02。
         let latest = repo.fetch_latest_date().await.expect("fetch_latest_date");
         assert!(latest.is_some_and(|d| d >= test_date()));
+
+        cleanup().await;
+    }
+
+    /// 新增期間後的回填依據：找出「已有結果、但缺少該期間」的基準日。
+    #[tokio::test]
+    #[cfg_attr(
+        not(feature = "integration-tests"),
+        ignore = "需要外部服務（PostgreSQL/Redis），請加 --features integration-tests 執行"
+    )]
+    async fn test_fetch_dates_missing_period() {
+        dotenvy::dotenv().ok();
+        if database::ping().await.is_err() {
+            println!("跳過 test_fetch_dates_missing_period：無資料庫連接");
+            return;
+        }
+
+        let repo = PgCagrRepository::new();
+        cleanup().await;
+
+        // 只有 Y1 的基準日 —— 缺 Y7，必須被列為待回填。
+        repo.save_batch(&[complete_record(FAKE_SYMBOL, CagrPeriod::Y1, dec!(5))])
+            .await
+            .expect("save_batch");
+        let pending = repo
+            .fetch_dates_missing_period(CagrPeriod::Y7)
+            .await
+            .expect("fetch_dates_missing_period");
+        assert!(pending.contains(&test_date()));
+        assert!(
+            pending.windows(2).all(|pair| pair[0] < pair[1]),
+            "回傳的基準日必須由早至晚且不重複"
+        );
+
+        // 補上 Y7 之後該日期就不該再出現。
+        repo.save_batch(&[complete_record(FAKE_SYMBOL, CagrPeriod::Y7, dec!(5))])
+            .await
+            .expect("save_batch Y7");
+        let pending = repo
+            .fetch_dates_missing_period(CagrPeriod::Y7)
+            .await
+            .expect("fetch_dates_missing_period again");
+        assert!(!pending.contains(&test_date()));
 
         cleanup().await;
     }

--- a/src/infra/database/repository/performance.rs
+++ b/src/infra/database/repository/performance.rs
@@ -1,0 +1,1028 @@
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use chrono::NaiveDate;
+use sqlx::Row;
+
+use crate::domain::performance::entity::{
+    CagrCoverage, CagrMetric, CagrPeriod, StockCagr as DomainStockCagr,
+};
+use crate::domain::performance::query::{
+    CagrRankingItem, CagrRankingPage, CagrRankingQuery, CagrSortKey,
+};
+use crate::domain::performance::repository::CagrRepository;
+use crate::infra::database;
+use crate::infra::database::table::performance::stock_cagr::StockCagr as TableStockCagr;
+
+/// 單批寫入的最大列數。
+///
+/// PostgreSQL 單一敘述最多 65535 個參數，本表以 26 個陣列參數承載任意列數，
+/// 參數個數不受列數影響；限制批量的目的是控制單次網路封包與伺服器端的
+/// 記憶體用量（全市場 × 8 期間約 1.8 萬列）。
+const SAVE_BATCH_SIZE: usize = 2_000;
+
+/// 讀取用的欄位清單。
+///
+/// 與 [`TableStockCagr`] 的欄位順序一致；集中於此避免各查詢各寫一份而失去同步。
+const SELECT_COLUMNS: &str = r#"
+    date, stock_symbol, period, base_date, base_price, end_price, years,
+    price_end_shares, price_end_value, price_return_pct, price_cagr_pct,
+    total_shares, total_cash, total_end_value, total_return_pct, total_cagr_pct,
+    reinv_shares, reinv_cash, reinv_end_value, reinv_return_pct, reinv_cagr_pct,
+    first_quote_date, shortfall_days, data_complete, has_anomaly, dividend_events
+"#;
+
+/// 基於 PostgreSQL 的每日 CAGR 倉儲實現 (PgCagrRepository)。
+///
+/// 對應資料表 `public.stock_cagr`，主鍵為 `(date, stock_symbol, period)`。
+pub struct PgCagrRepository;
+
+impl PgCagrRepository {
+    /// 建立新的 PgCagrRepository 實例。
+    pub fn new() -> Self {
+        PgCagrRepository
+    }
+}
+
+impl Default for PgCagrRepository {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// 依報酬口徑取得對應的年化報酬率欄位名稱。
+///
+/// 回傳值是編譯期字面值，**不是**呼叫端傳入的字串——排序鍵必須以白名單
+/// 映射，任何把外部輸入拼進 SQL 的寫法都是注入破口。
+fn cagr_column(metric: CagrMetric) -> &'static str {
+    match metric {
+        CagrMetric::Price => "price_cagr_pct",
+        CagrMetric::Total => "total_cagr_pct",
+        CagrMetric::Reinvested => "reinv_cagr_pct",
+    }
+}
+
+/// 依報酬口徑取得對應的區間總報酬率欄位名稱。
+///
+/// 同 [`cagr_column`]：回傳編譯期字面值，排序鍵一律走白名單映射。
+fn return_column(metric: CagrMetric) -> &'static str {
+    match metric {
+        CagrMetric::Price => "price_return_pct",
+        CagrMetric::Total => "total_return_pct",
+        CagrMetric::Reinvested => "reinv_return_pct",
+    }
+}
+
+/// 依（排序鍵, 口徑）取得排行榜排序所用的欄位名稱。
+///
+/// 兩個維度各自是封閉列舉，組合後仍只映射到六個編譯期字面值；
+/// 呼叫端無從提供任何 SQL 片段。
+fn sort_column(sort: CagrSortKey, metric: CagrMetric) -> &'static str {
+    match sort {
+        CagrSortKey::Cagr => cagr_column(metric),
+        CagrSortKey::TotalReturn => return_column(metric),
+    }
+}
+
+/// 排行榜查詢的共用 FROM／WHERE 片段（不含排序鍵相關條件）。
+///
+/// 綁定參數：`$1` 基準日、`$2` 期間代碼、`$3` 市場編號（NULL 不篩選）、
+/// `$4` 產業編號（NULL 不篩選）、`$5` 關鍵字 ILIKE 樣式（NULL 不篩選）。
+/// 排行榜與總筆數共用同一份條件，避免兩者因條件不同步而讓分頁錯亂。
+const RANKING_FROM_WHERE: &str = r#"
+FROM stock_cagr c
+JOIN stocks s ON s.stock_symbol = c.stock_symbol
+WHERE c.date = $1
+  AND c.period = $2
+  AND ($3::int IS NULL OR s.stock_exchange_market_id = $3)
+  AND ($4::int IS NULL OR s.stock_industry_id = $4)
+  AND ($5::text IS NULL OR c.stock_symbol ILIKE $5 OR s."Name" ILIKE $5)
+"#;
+
+/// 排行榜查詢的欄位清單（帶 `c.` 前綴）。
+///
+/// 與 [`SELECT_COLUMNS`] 內容相同，但因 JOIN `stocks` 後 `stock_symbol`
+/// 會有歧義，必須逐欄限定來源資料表。
+const RANKING_SELECT_COLUMNS: &str = r#"
+    c.date, c.stock_symbol, c.period, c.base_date, c.base_price, c.end_price, c.years,
+    c.price_end_shares, c.price_end_value, c.price_return_pct, c.price_cagr_pct,
+    c.total_shares, c.total_cash, c.total_end_value, c.total_return_pct, c.total_cagr_pct,
+    c.reinv_shares, c.reinv_cash, c.reinv_end_value, c.reinv_return_pct, c.reinv_cagr_pct,
+    c.first_quote_date, c.shortfall_days, c.data_complete, c.has_anomaly, c.dividend_events
+"#;
+
+/// 排行榜查詢的資料列：CAGR 主體加上股票名稱、產業分類與名次。
+#[derive(sqlx::FromRow)]
+struct RankingRow {
+    /// CAGR 計算結果本體。
+    #[sqlx(flatten)]
+    cagr: TableStockCagr,
+    /// 股票名稱。
+    name: String,
+    /// 產業分類編號。
+    industry_id: i32,
+    /// 名次；資料不足（排序鍵為 NULL）者為 `None`。
+    rank: Option<i64>,
+}
+
+/// 將關鍵字轉成 ILIKE 樣式，並跳脫萬用字元。
+///
+/// 使用者輸入的 `%` 與 `_` 應該當成字面字元比對；不跳脫的話輸入一個 `%`
+/// 就會匹配全市場，看起來像是篩選失效。
+fn keyword_pattern(keyword: &str) -> String {
+    let escaped = keyword
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_");
+    format!("%{escaped}%")
+}
+
+/// 將資料列批次還原為領域實體，並依期間長度由短至長排序。
+fn rows_to_domain(rows: Vec<TableStockCagr>) -> Result<Vec<DomainStockCagr>> {
+    rows.into_iter().map(|row| row.to_domain()).collect()
+}
+
+#[async_trait]
+impl CagrRepository for PgCagrRepository {
+    /// 批次 upsert 指定基準日的 CAGR 計算結果。
+    ///
+    /// 刻意不使用 `COPY`：本專案的 [`CopyIn`](crate::infra::database) 無法處理
+    /// `ON CONFLICT`，同日重跑會整批因主鍵重複而失敗。改以 `UNNEST` 展開
+    /// 26 個陣列參數做多列插入，兼顧「一次往返寫入數千列」與 upsert 語意。
+    async fn save_batch(&self, records: &[DomainStockCagr]) -> Result<u64> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+
+        let sql = r#"
+INSERT INTO stock_cagr (
+    date, stock_symbol, period, base_date, base_price, end_price, years,
+    price_end_shares, price_end_value, price_return_pct, price_cagr_pct,
+    total_shares, total_cash, total_end_value, total_return_pct, total_cagr_pct,
+    reinv_shares, reinv_cash, reinv_end_value, reinv_return_pct, reinv_cagr_pct,
+    first_quote_date, shortfall_days, data_complete, has_anomaly, dividend_events
+)
+SELECT * FROM UNNEST(
+    $1::date[], $2::varchar[], $3::varchar[], $4::date[], $5::numeric[], $6::numeric[], $7::numeric[],
+    $8::numeric[], $9::numeric[], $10::numeric[], $11::numeric[],
+    $12::numeric[], $13::numeric[], $14::numeric[], $15::numeric[], $16::numeric[],
+    $17::numeric[], $18::numeric[], $19::numeric[], $20::numeric[], $21::numeric[],
+    $22::date[], $23::int4[], $24::bool[], $25::bool[], $26::int4[]
+) AS t(
+    date, stock_symbol, period, base_date, base_price, end_price, years,
+    price_end_shares, price_end_value, price_return_pct, price_cagr_pct,
+    total_shares, total_cash, total_end_value, total_return_pct, total_cagr_pct,
+    reinv_shares, reinv_cash, reinv_end_value, reinv_return_pct, reinv_cagr_pct,
+    first_quote_date, shortfall_days, data_complete, has_anomaly, dividend_events
+)
+ON CONFLICT (date, stock_symbol, period) DO UPDATE SET
+    base_date = EXCLUDED.base_date,
+    base_price = EXCLUDED.base_price,
+    end_price = EXCLUDED.end_price,
+    years = EXCLUDED.years,
+    price_end_shares = EXCLUDED.price_end_shares,
+    price_end_value = EXCLUDED.price_end_value,
+    price_return_pct = EXCLUDED.price_return_pct,
+    price_cagr_pct = EXCLUDED.price_cagr_pct,
+    total_shares = EXCLUDED.total_shares,
+    total_cash = EXCLUDED.total_cash,
+    total_end_value = EXCLUDED.total_end_value,
+    total_return_pct = EXCLUDED.total_return_pct,
+    total_cagr_pct = EXCLUDED.total_cagr_pct,
+    reinv_shares = EXCLUDED.reinv_shares,
+    reinv_cash = EXCLUDED.reinv_cash,
+    reinv_end_value = EXCLUDED.reinv_end_value,
+    reinv_return_pct = EXCLUDED.reinv_return_pct,
+    reinv_cagr_pct = EXCLUDED.reinv_cagr_pct,
+    first_quote_date = EXCLUDED.first_quote_date,
+    shortfall_days = EXCLUDED.shortfall_days,
+    data_complete = EXCLUDED.data_complete,
+    has_anomaly = EXCLUDED.has_anomaly,
+    dividend_events = EXCLUDED.dividend_events,
+    updated_time = now();
+"#;
+
+        let mut affected: u64 = 0;
+
+        for chunk in records.chunks(SAVE_BATCH_SIZE) {
+            let len = chunk.len();
+            let mut dates = Vec::with_capacity(len);
+            let mut symbols = Vec::with_capacity(len);
+            let mut periods = Vec::with_capacity(len);
+            let mut base_dates = Vec::with_capacity(len);
+            let mut base_prices = Vec::with_capacity(len);
+            let mut end_prices = Vec::with_capacity(len);
+            let mut years = Vec::with_capacity(len);
+            let mut price_end_shares = Vec::with_capacity(len);
+            let mut price_end_values = Vec::with_capacity(len);
+            let mut price_return_pcts = Vec::with_capacity(len);
+            let mut price_cagr_pcts = Vec::with_capacity(len);
+            let mut total_shares = Vec::with_capacity(len);
+            let mut total_cashes = Vec::with_capacity(len);
+            let mut total_end_values = Vec::with_capacity(len);
+            let mut total_return_pcts = Vec::with_capacity(len);
+            let mut total_cagr_pcts = Vec::with_capacity(len);
+            let mut reinv_shares = Vec::with_capacity(len);
+            let mut reinv_cashes = Vec::with_capacity(len);
+            let mut reinv_end_values = Vec::with_capacity(len);
+            let mut reinv_return_pcts = Vec::with_capacity(len);
+            let mut reinv_cagr_pcts = Vec::with_capacity(len);
+            let mut first_quote_dates = Vec::with_capacity(len);
+            let mut shortfall_days = Vec::with_capacity(len);
+            let mut data_completes = Vec::with_capacity(len);
+            let mut has_anomalies = Vec::with_capacity(len);
+            let mut dividend_events = Vec::with_capacity(len);
+
+            for record in chunk {
+                let row = TableStockCagr::from(record);
+                dates.push(row.date);
+                symbols.push(row.stock_symbol);
+                periods.push(row.period);
+                base_dates.push(row.base_date);
+                base_prices.push(row.base_price);
+                end_prices.push(row.end_price);
+                years.push(row.years);
+                price_end_shares.push(row.price_end_shares);
+                price_end_values.push(row.price_end_value);
+                price_return_pcts.push(row.price_return_pct);
+                price_cagr_pcts.push(row.price_cagr_pct);
+                total_shares.push(row.total_shares);
+                total_cashes.push(row.total_cash);
+                total_end_values.push(row.total_end_value);
+                total_return_pcts.push(row.total_return_pct);
+                total_cagr_pcts.push(row.total_cagr_pct);
+                reinv_shares.push(row.reinv_shares);
+                reinv_cashes.push(row.reinv_cash);
+                reinv_end_values.push(row.reinv_end_value);
+                reinv_return_pcts.push(row.reinv_return_pct);
+                reinv_cagr_pcts.push(row.reinv_cagr_pct);
+                first_quote_dates.push(row.first_quote_date);
+                shortfall_days.push(row.shortfall_days);
+                data_completes.push(row.data_complete);
+                has_anomalies.push(row.has_anomaly);
+                dividend_events.push(row.dividend_events);
+            }
+
+            let result = sqlx::query(sql)
+                .bind(&dates)
+                .bind(&symbols)
+                .bind(&periods)
+                .bind(&base_dates)
+                .bind(&base_prices)
+                .bind(&end_prices)
+                .bind(&years)
+                .bind(&price_end_shares)
+                .bind(&price_end_values)
+                .bind(&price_return_pcts)
+                .bind(&price_cagr_pcts)
+                .bind(&total_shares)
+                .bind(&total_cashes)
+                .bind(&total_end_values)
+                .bind(&total_return_pcts)
+                .bind(&total_cagr_pcts)
+                .bind(&reinv_shares)
+                .bind(&reinv_cashes)
+                .bind(&reinv_end_values)
+                .bind(&reinv_return_pcts)
+                .bind(&reinv_cagr_pcts)
+                .bind(&first_quote_dates)
+                .bind(&shortfall_days)
+                .bind(&data_completes)
+                .bind(&has_anomalies)
+                .bind(&dividend_events)
+                .execute(database::get_connection())
+                .await
+                .context("Failed to upsert stock_cagr in PgCagrRepository::save_batch")?;
+
+            affected += result.rows_affected();
+        }
+
+        Ok(affected)
+    }
+
+    /// 取得指定基準日與期間的排行榜。
+    ///
+    /// 除了 `data_complete = true`，也排除該口徑年化報酬率為 `NULL` 的資料列——
+    /// 長期間不提供純價格口徑（見 [`CagrPeriod::supports_price_metric`]），
+    /// 若不過濾，依 `price_cagr_pct` 排序的結果會混入一批空值列。
+    async fn fetch_ranking(
+        &self,
+        date: NaiveDate,
+        period: CagrPeriod,
+        metric: CagrMetric,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<DomainStockCagr>> {
+        // 排序鍵來自白名單映射的字面值，未拼接任何外部輸入；
+        // date/period/limit/offset 一律走繫結參數。
+        let column = cagr_column(metric);
+        let sql = format!(
+            r#"
+SELECT {SELECT_COLUMNS}
+FROM stock_cagr
+WHERE date = $1
+  AND period = $2
+  AND data_complete = true
+  AND {column} IS NOT NULL
+ORDER BY {column} DESC, stock_symbol
+LIMIT $3 OFFSET $4
+"#
+        );
+
+        let rows = sqlx::query_as::<_, TableStockCagr>(sqlx::AssertSqlSafe(sql.as_str()))
+            .bind(date)
+            .bind(period.code())
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(database::get_connection())
+            .await
+            .context("Failed to fetch stock_cagr ranking in PgCagrRepository::fetch_ranking")?;
+
+        rows_to_domain(rows)
+    }
+
+    /// 依完整查詢條件取得排行榜單頁結果。
+    ///
+    /// 四個要點：
+    ///
+    /// 1. 名次由「排序鍵可算」的資料列以 `ROW_NUMBER()` 產生，資料不足者
+    ///    不佔名次（`rank` 為 `NULL`）且以 `rankable DESC` 排在所有可算列
+    ///    之後——否則排行榜會出現「第 1204 名，報酬率 —」這種無意義的列。
+    /// 2. **名次是全市場名次，與篩選條件無關**：`ROW_NUMBER()` 在套用市場／
+    ///    產業／關鍵字篩選之前就算完，因此篩出單一產業後可能看到 1、17、43，
+    ///    而不是 1、2、3。這讓 `rank` 成為股票的穩定屬性。
+    /// 3. 總筆數則相反，是**套用篩選後**的筆數，且另以一次 `COUNT(*)` 取得
+    ///    而非取自本頁的視窗欄位：位移超出範圍時本頁是空的，若從資料列取
+    ///    `total` 會退化成 0 而讓分頁失效。
+    /// 4. 排序欄位一律由 [`sort_column`] 白名單映射為字面值；所有外部輸入
+    ///    （日期、期間、市場、產業、關鍵字、分頁）全部走繫結參數。
+    async fn fetch_ranking_page(&self, query: &CagrRankingQuery) -> Result<CagrRankingPage> {
+        let column = sort_column(query.sort, query.metric);
+        let pattern = query.keyword.as_deref().map(keyword_pattern);
+
+        // 可算（rankable）＝ 資料齊全且該排序鍵不為 NULL；長期間的純價格口徑
+        // 會出現 data_complete = true 但欄位為 NULL 的列，必須一併視為不可算。
+        let rankable = format!("(c.data_complete AND c.{column} IS NOT NULL)");
+        let incomplete_filter = format!("  AND ($6::bool OR {rankable})");
+
+        let count_sql = format!("SELECT COUNT(*) {RANKING_FROM_WHERE}\n{incomplete_filter}\n");
+        let total: (i64,) = sqlx::query_as(sqlx::AssertSqlSafe(count_sql.as_str()))
+            .bind(query.date)
+            .bind(query.period.code())
+            .bind(query.market_id)
+            .bind(query.industry_id)
+            .bind(pattern.as_deref())
+            .bind(query.include_incomplete)
+            .fetch_one(database::get_connection())
+            .await
+            .context("Failed to count stock_cagr in PgCagrRepository::fetch_ranking_page")?;
+
+        // 名次在 `ranked` CTE（尚未套用任何篩選）就算完：rank 是「該
+        // (基準日, 期間, 口徑) 之下全市場的名次」，切換市場／產業／關鍵字
+        // 篩選不會改變同一檔股票的名次。若在篩選後重新編號，篩出半導體
+        // 後的「第 1 名」其實不是市場第 1 名，顯示成 1 會誤導使用者。
+        let sql = format!(
+            r#"
+WITH ranked AS (
+    SELECT {RANKING_SELECT_COLUMNS},
+           {rankable} AS rankable,
+           CASE
+               WHEN {rankable} THEN ROW_NUMBER() OVER (
+                   PARTITION BY {rankable}
+                   ORDER BY c.{column} DESC, c.stock_symbol
+               )
+           END AS "rank"
+    FROM stock_cagr c
+    WHERE c.date = $1
+      AND c.period = $2
+),
+filtered AS (
+    SELECT r.*,
+           s."Name" AS name,
+           s.stock_industry_id AS industry_id
+    FROM ranked r
+    JOIN stocks s ON s.stock_symbol = r.stock_symbol
+    WHERE ($3::int IS NULL OR s.stock_exchange_market_id = $3)
+      AND ($4::int IS NULL OR s.stock_industry_id = $4)
+      AND ($5::text IS NULL OR r.stock_symbol ILIKE $5 OR s."Name" ILIKE $5)
+      AND ($6::bool OR r.rankable)
+)
+SELECT f.*
+FROM filtered f
+ORDER BY f.rankable DESC, f."rank" NULLS LAST, f.stock_symbol
+LIMIT $7 OFFSET $8
+"#
+        );
+
+        let rows = sqlx::query_as::<_, RankingRow>(sqlx::AssertSqlSafe(sql.as_str()))
+            .bind(query.date)
+            .bind(query.period.code())
+            .bind(query.market_id)
+            .bind(query.industry_id)
+            .bind(pattern.as_deref())
+            .bind(query.include_incomplete)
+            .bind(query.limit)
+            .bind(query.offset)
+            .fetch_all(database::get_connection())
+            .await
+            .context("Failed to fetch stock_cagr page in PgCagrRepository::fetch_ranking_page")?;
+
+        let items = rows
+            .into_iter()
+            .map(|row| {
+                Ok(CagrRankingItem {
+                    cagr: row.cagr.to_domain()?,
+                    name: row.name,
+                    industry_id: row.industry_id,
+                    rank: row.rank,
+                })
+            })
+            .collect::<Result<Vec<CagrRankingItem>>>()?;
+
+        // 涵蓋統計刻意不套用篩選條件：它回答的是「這個 (基準日, 期間) 的
+        // 母體有多少檔算得出來」，是存活者偏誤的揭露依據，不隨畫面篩選變動。
+        let coverage = self
+            .fetch_coverage(query.date, query.period, query.metric)
+            .await?;
+
+        Ok(CagrRankingPage {
+            items,
+            total: total.0,
+            coverage,
+        })
+    }
+
+    /// 取得單一個股在指定基準日的所有期間結果（含資料不足者）。
+    ///
+    /// 期間代碼在資料庫是字串，字典序（M3 < M6 < Y1 < Y10 < Y1H …）與時間長度
+    /// 不一致，故排序改在領域層以 [`CagrPeriod::months`] 進行。
+    async fn fetch_by_symbol(
+        &self,
+        date: NaiveDate,
+        stock_symbol: &str,
+    ) -> Result<Vec<DomainStockCagr>> {
+        let sql = format!(
+            r#"
+SELECT {SELECT_COLUMNS}
+FROM stock_cagr
+WHERE date = $1 AND stock_symbol = $2
+"#
+        );
+
+        let rows = sqlx::query_as::<_, TableStockCagr>(sqlx::AssertSqlSafe(sql.as_str()))
+            .bind(date)
+            .bind(stock_symbol)
+            .fetch_all(database::get_connection())
+            .await
+            .context("Failed to fetch stock_cagr in PgCagrRepository::fetch_by_symbol")?;
+
+        let mut result = rows_to_domain(rows)?;
+        result.sort_by_key(|item| item.period.months());
+
+        Ok(result)
+    }
+
+    /// 取得指定基準日與期間的樣本涵蓋統計。
+    ///
+    /// 五個計數以單一查詢的 `COUNT(*) FILTER` 完成，避免多次往返造成
+    /// 各計數取自不同時點的資料而彼此矛盾。
+    async fn fetch_coverage(
+        &self,
+        date: NaiveDate,
+        period: CagrPeriod,
+        metric: CagrMetric,
+    ) -> Result<CagrCoverage> {
+        // 同 fetch_ranking：欄位名稱來自白名單字面值。
+        let column = cagr_column(metric);
+        let sql = format!(
+            r#"
+SELECT
+    COUNT(*) AS universe,
+    COUNT(*) FILTER (WHERE data_complete) AS counted,
+    COUNT(*) FILTER (WHERE NOT data_complete) AS incomplete,
+    COUNT(*) FILTER (WHERE has_anomaly) AS anomaly_flagged,
+    COUNT(*) FILTER (WHERE data_complete AND {column} > 0) AS positive
+FROM stock_cagr
+WHERE date = $1 AND period = $2
+"#
+        );
+
+        let row = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()))
+            .bind(date)
+            .bind(period.code())
+            .fetch_one(database::get_connection())
+            .await
+            .context("Failed to fetch coverage in PgCagrRepository::fetch_coverage")?;
+
+        Ok(CagrCoverage {
+            universe: row.try_get("universe")?,
+            counted: row.try_get("counted")?,
+            incomplete: row.try_get("incomplete")?,
+            anomaly_flagged: row.try_get("anomaly_flagged")?,
+            positive: row.try_get("positive")?,
+        })
+    }
+
+    /// 取得最新一個已完成計算的基準日。
+    async fn fetch_latest_date(&self) -> Result<Option<NaiveDate>> {
+        let row: (Option<NaiveDate>,) = sqlx::query_as("SELECT MAX(date) FROM stock_cagr")
+            .fetch_one(database::get_connection())
+            .await
+            .context("Failed to fetch latest date in PgCagrRepository::fetch_latest_date")?;
+
+        Ok(row.0)
+    }
+
+    /// 刪除早於指定日期的歷史資料。
+    async fn delete_before(&self, date: NaiveDate) -> Result<u64> {
+        let result = sqlx::query("DELETE FROM stock_cagr WHERE date < $1")
+            .bind(date)
+            .execute(database::get_connection())
+            .await
+            .context("Failed to delete stock_cagr in PgCagrRepository::delete_before")?;
+
+        Ok(result.rows_affected())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::performance::entity::SimulationOutcome;
+    use rust_decimal::Decimal;
+    use rust_decimal_macros::dec;
+
+    /// 測試專用的假代號前綴；真實市場不存在此代號。
+    const FAKE_SYMBOL: &str = "79979";
+    /// 排行榜測試用的另外兩個假代號。
+    const FAKE_SYMBOL_B: &str = "79979B";
+    const FAKE_SYMBOL_C: &str = "79979C";
+    const FAKE_SYMBOL_D: &str = "79979D";
+
+    /// 測試基準日。
+    ///
+    /// 刻意選 1990-01-02 這種遠早於本功能上線的日期：`fetch_coverage`／
+    /// `fetch_ranking` 是以 (date, period) 為範圍的整體統計，若沿用近期日期，
+    /// 正式資料會混進計數而讓斷言時好時壞。
+    fn test_date() -> NaiveDate {
+        NaiveDate::from_ymd_opt(1990, 1, 2).unwrap()
+    }
+
+    /// 建立一筆資料齊全的測試資料。
+    fn complete_record(symbol: &str, period: CagrPeriod, cagr: Decimal) -> DomainStockCagr {
+        let outcome = SimulationOutcome {
+            end_shares: dec!(100.5),
+            cash_received: dec!(250.0),
+            end_value: dec!(12000.0),
+            total_return_pct: dec!(20.0),
+            cagr_pct: cagr,
+        };
+
+        DomainStockCagr {
+            date: test_date(),
+            stock_symbol: symbol.to_string(),
+            period,
+            base_date: NaiveDate::from_ymd_opt(1989, 1, 3),
+            base_price: Some(dec!(100.0)),
+            end_price: Some(dec!(119.4)),
+            years: Some(dec!(1.0)),
+            price: Some(SimulationOutcome {
+                cash_received: Decimal::ZERO,
+                cagr_pct: cagr - dec!(1),
+                ..outcome
+            }),
+            total: Some(outcome),
+            reinvested: Some(SimulationOutcome {
+                cash_received: Decimal::ZERO,
+                cagr_pct: cagr + dec!(1),
+                ..outcome
+            }),
+            first_quote_date: NaiveDate::from_ymd_opt(1988, 1, 4),
+            shortfall_days: Some(0),
+            data_complete: true,
+            has_anomaly: false,
+            dividend_events: 2,
+        }
+    }
+
+    /// 建立一筆資料不足的測試資料（所有數值欄位皆為 None）。
+    fn incomplete_record(symbol: &str, period: CagrPeriod) -> DomainStockCagr {
+        DomainStockCagr {
+            date: test_date(),
+            stock_symbol: symbol.to_string(),
+            period,
+            base_date: None,
+            base_price: None,
+            end_price: None,
+            years: None,
+            price: None,
+            total: None,
+            reinvested: None,
+            first_quote_date: NaiveDate::from_ymd_opt(1989, 6, 1),
+            shortfall_days: None,
+            data_complete: false,
+            has_anomaly: true,
+            dividend_events: 0,
+        }
+    }
+
+    /// 清理測試寫入的資料列；測試結束務必呼叫，避免污染資料庫。
+    async fn cleanup() {
+        let _ = sqlx::query("DELETE FROM stock_cagr WHERE stock_symbol = ANY($1)")
+            .bind(vec![
+                FAKE_SYMBOL.to_string(),
+                FAKE_SYMBOL_B.to_string(),
+                FAKE_SYMBOL_C.to_string(),
+                FAKE_SYMBOL_D.to_string(),
+            ])
+            .execute(database::get_connection())
+            .await;
+    }
+
+    #[tokio::test]
+    #[cfg_attr(
+        not(feature = "integration-tests"),
+        ignore = "需要外部服務（PostgreSQL/Redis），請加 --features integration-tests 執行"
+    )]
+    async fn test_save_batch_round_trip_and_idempotent() {
+        dotenvy::dotenv().ok();
+        if database::ping().await.is_err() {
+            println!("跳過 test_save_batch_round_trip_and_idempotent：無資料庫連接");
+            return;
+        }
+
+        let repo = PgCagrRepository::new();
+        cleanup().await;
+
+        // 1. 寫入後讀回應一致
+        let record = complete_record(FAKE_SYMBOL, CagrPeriod::Y1, dec!(12.3456));
+        let affected = repo
+            .save_batch(std::slice::from_ref(&record))
+            .await
+            .expect("save_batch");
+        assert_eq!(affected, 1);
+
+        let fetched = repo
+            .fetch_by_symbol(test_date(), FAKE_SYMBOL)
+            .await
+            .expect("fetch_by_symbol");
+        assert_eq!(fetched.len(), 1);
+        let first = &fetched[0];
+        assert_eq!(first.stock_symbol, record.stock_symbol);
+        assert_eq!(first.period, CagrPeriod::Y1);
+        assert_eq!(first.base_date, record.base_date);
+        assert_eq!(first.total, record.total);
+        assert_eq!(first.reinvested, record.reinvested);
+        assert!(first.data_complete);
+        assert_eq!(first.dividend_events, 2);
+
+        // 2. 同一主鍵重複寫入是覆蓋而非新增
+        let mut updated = complete_record(FAKE_SYMBOL, CagrPeriod::Y1, dec!(99.9999));
+        updated.dividend_events = 7;
+        repo.save_batch(&[updated]).await.expect("save_batch again");
+
+        let fetched = repo
+            .fetch_by_symbol(test_date(), FAKE_SYMBOL)
+            .await
+            .expect("fetch_by_symbol");
+        assert_eq!(fetched.len(), 1, "重複 upsert 不應新增資料列");
+        assert_eq!(fetched[0].total.map(|o| o.cagr_pct), Some(dec!(99.9999)));
+        assert_eq!(fetched[0].dividend_events, 7);
+
+        cleanup().await;
+    }
+
+    #[tokio::test]
+    #[cfg_attr(
+        not(feature = "integration-tests"),
+        ignore = "需要外部服務（PostgreSQL/Redis），請加 --features integration-tests 執行"
+    )]
+    async fn test_incomplete_record_reads_back_as_none() {
+        dotenvy::dotenv().ok();
+        if database::ping().await.is_err() {
+            println!("跳過 test_incomplete_record_reads_back_as_none：無資料庫連接");
+            return;
+        }
+
+        let repo = PgCagrRepository::new();
+        cleanup().await;
+
+        repo.save_batch(&[incomplete_record(FAKE_SYMBOL, CagrPeriod::Y10)])
+            .await
+            .expect("save_batch");
+
+        let fetched = repo
+            .fetch_by_symbol(test_date(), FAKE_SYMBOL)
+            .await
+            .expect("fetch_by_symbol");
+        assert_eq!(fetched.len(), 1);
+        let item = &fetched[0];
+        assert!(!item.data_complete);
+        assert!(item.base_price.is_none());
+        assert!(item.end_price.is_none());
+        assert!(item.years.is_none());
+        assert!(item.price.is_none());
+        assert!(item.total.is_none(), "資料不足時不可讀成 0，必須是 None");
+        assert!(item.reinvested.is_none());
+        assert!(item.shortfall_days.is_none());
+        assert!(item.has_anomaly);
+
+        cleanup().await;
+    }
+
+    #[tokio::test]
+    #[cfg_attr(
+        not(feature = "integration-tests"),
+        ignore = "需要外部服務（PostgreSQL/Redis），請加 --features integration-tests 執行"
+    )]
+    async fn test_fetch_by_symbol_sorted_by_period_length() {
+        dotenvy::dotenv().ok();
+        if database::ping().await.is_err() {
+            println!("跳過 test_fetch_by_symbol_sorted_by_period_length：無資料庫連接");
+            return;
+        }
+
+        let repo = PgCagrRepository::new();
+        cleanup().await;
+
+        // 刻意以「字典序會排錯」的組合驗證：Y10 字典序在 Y1H 之前。
+        let records = vec![
+            complete_record(FAKE_SYMBOL, CagrPeriod::Y10, dec!(1)),
+            complete_record(FAKE_SYMBOL, CagrPeriod::M3, dec!(2)),
+            incomplete_record(FAKE_SYMBOL, CagrPeriod::Y1H),
+            complete_record(FAKE_SYMBOL, CagrPeriod::Y1, dec!(3)),
+        ];
+        repo.save_batch(&records).await.expect("save_batch");
+
+        let fetched = repo
+            .fetch_by_symbol(test_date(), FAKE_SYMBOL)
+            .await
+            .expect("fetch_by_symbol");
+        let periods: Vec<CagrPeriod> = fetched.iter().map(|item| item.period).collect();
+        assert_eq!(
+            periods,
+            vec![
+                CagrPeriod::M3,
+                CagrPeriod::Y1,
+                CagrPeriod::Y1H,
+                CagrPeriod::Y10
+            ],
+            "應依期間長度排序，且包含 data_complete = false 的列"
+        );
+
+        cleanup().await;
+    }
+
+    #[tokio::test]
+    #[cfg_attr(
+        not(feature = "integration-tests"),
+        ignore = "需要外部服務（PostgreSQL/Redis），請加 --features integration-tests 執行"
+    )]
+    async fn test_fetch_ranking_and_coverage() {
+        dotenvy::dotenv().ok();
+        if database::ping().await.is_err() {
+            println!("跳過 test_fetch_ranking_and_coverage：無資料庫連接");
+            return;
+        }
+
+        let repo = PgCagrRepository::new();
+        cleanup().await;
+
+        // 三筆可算（年化 5 / 15 / -3）＋ 一筆資料不足（同時標記異常）。
+        let records = vec![
+            complete_record(FAKE_SYMBOL, CagrPeriod::Y1, dec!(5)),
+            complete_record(FAKE_SYMBOL_B, CagrPeriod::Y1, dec!(15)),
+            complete_record(FAKE_SYMBOL_C, CagrPeriod::Y1, dec!(-3)),
+        ];
+        repo.save_batch(&records).await.expect("save_batch");
+        // 再寫入資料不足的列：Y1 一筆（驗證排行榜排除它）、Y2 兩筆（驗證涵蓋率計數）。
+        let incompletes = vec![
+            incomplete_record(FAKE_SYMBOL_D, CagrPeriod::Y1),
+            incomplete_record(FAKE_SYMBOL, CagrPeriod::Y2),
+            incomplete_record(FAKE_SYMBOL_C, CagrPeriod::Y2),
+        ];
+        repo.save_batch(&incompletes).await.expect("save_batch");
+
+        // 排行榜：依 total 口徑由高至低，且不含資料不足者。
+        let ranking = repo
+            .fetch_ranking(test_date(), CagrPeriod::Y1, CagrMetric::Total, 10, 0)
+            .await
+            .expect("fetch_ranking");
+        let symbols: Vec<&str> = ranking
+            .iter()
+            .map(|item| item.stock_symbol.as_str())
+            .collect();
+        assert_eq!(
+            symbols,
+            vec![FAKE_SYMBOL_B, FAKE_SYMBOL, FAKE_SYMBOL_C],
+            "應依年化報酬率由高至低，且不含 data_complete = false 的 {FAKE_SYMBOL_D}"
+        );
+        assert!(ranking.iter().all(|item| item.data_complete));
+
+        // offset/limit 亦應生效。
+        let paged = repo
+            .fetch_ranking(test_date(), CagrPeriod::Y1, CagrMetric::Total, 1, 1)
+            .await
+            .expect("fetch_ranking paged");
+        assert_eq!(paged.len(), 1);
+        assert_eq!(paged[0].stock_symbol, FAKE_SYMBOL);
+
+        // 涵蓋率統計：Y1 期間共 4 列，3 列可算（正報酬 2 檔），1 列資料不足且標記異常。
+        let coverage = repo
+            .fetch_coverage(test_date(), CagrPeriod::Y1, CagrMetric::Total)
+            .await
+            .expect("fetch_coverage");
+        assert_eq!(coverage.universe, 4);
+        assert_eq!(coverage.counted, 3);
+        assert_eq!(coverage.incomplete, 1);
+        assert_eq!(coverage.anomaly_flagged, 1);
+        assert_eq!(coverage.positive, 2);
+
+        // Y2 期間共 2 列，皆為資料不足且標記異常。
+        let coverage = repo
+            .fetch_coverage(test_date(), CagrPeriod::Y2, CagrMetric::Total)
+            .await
+            .expect("fetch_coverage");
+        assert_eq!(coverage.universe, 2);
+        assert_eq!(coverage.counted, 0);
+        assert_eq!(coverage.incomplete, 2);
+        assert_eq!(coverage.anomaly_flagged, 2);
+        assert_eq!(coverage.positive, 0);
+
+        // 最新基準日必定不早於測試用的 1990-01-02。
+        let latest = repo.fetch_latest_date().await.expect("fetch_latest_date");
+        assert!(latest.is_some_and(|d| d >= test_date()));
+
+        cleanup().await;
+    }
+
+    /// 排行榜分頁查詢：全市場名次、資料不足殿後、篩選與分頁語意。
+    ///
+    /// 名次必須是「未套用篩選的全市場名次」，因此以產業／關鍵字篩選後，
+    /// 同一檔股票的 `rank` 不可改變——這是前端把 rank 當成股票穩定屬性的
+    /// 前提。測試借用 `stocks` 既有的真實代號（唯讀取得）以滿足 JOIN，
+    /// 並只在遠早於本功能上線的 1990-01-02 寫入，結束後一律清除。
+    #[tokio::test]
+    #[cfg_attr(
+        not(feature = "integration-tests"),
+        ignore = "需要外部服務（PostgreSQL/Redis），請加 --features integration-tests 執行"
+    )]
+    async fn test_fetch_ranking_page_semantics() {
+        dotenvy::dotenv().ok();
+        if database::ping().await.is_err() {
+            println!("跳過 test_fetch_ranking_page_semantics：無資料庫連接");
+            return;
+        }
+
+        // 排行榜要 JOIN stocks，因此借用真實存在的代號；同產業取三檔以便
+        // 驗證「篩選後名次不重編」。
+        let borrowed: Vec<(String, i32)> = sqlx::query_as(
+            r#"SELECT stock_symbol, stock_industry_id FROM stocks
+               WHERE stock_industry_id = (
+                   SELECT stock_industry_id FROM stocks
+                   GROUP BY stock_industry_id HAVING COUNT(*) >= 4 LIMIT 1
+               )
+               ORDER BY stock_symbol LIMIT 4"#,
+        )
+        .fetch_all(database::get_connection())
+        .await
+        .expect("borrow stocks");
+        if borrowed.len() < 4 {
+            println!("跳過 test_fetch_ranking_page_semantics：stocks 樣本不足");
+            return;
+        }
+        let symbols: Vec<String> = borrowed.iter().map(|(symbol, _)| symbol.clone()).collect();
+        let industry = borrowed[0].1;
+        let other_industry: Option<i32> = sqlx::query_scalar(
+            "SELECT stock_industry_id FROM stocks WHERE stock_industry_id <> $1 LIMIT 1",
+        )
+        .bind(industry)
+        .fetch_optional(database::get_connection())
+        .await
+        .expect("other industry");
+
+        let cleanup_borrowed = || async {
+            let _ =
+                sqlx::query("DELETE FROM stock_cagr WHERE date = $1 AND stock_symbol = ANY($2)")
+                    .bind(test_date())
+                    .bind(&symbols)
+                    .execute(database::get_connection())
+                    .await;
+        };
+        cleanup_borrowed().await;
+
+        let repo = PgCagrRepository::new();
+        // 年化 30 / 20 / 10 三檔可算，第四檔資料不足。
+        let records = vec![
+            complete_record(&symbols[0], CagrPeriod::Y1, dec!(30)),
+            complete_record(&symbols[1], CagrPeriod::Y1, dec!(20)),
+            complete_record(&symbols[2], CagrPeriod::Y1, dec!(10)),
+            incomplete_record(&symbols[3], CagrPeriod::Y1),
+        ];
+        repo.save_batch(&records).await.expect("save_batch");
+
+        let base = CagrRankingQuery::new(test_date(), CagrPeriod::Y1);
+        let page = repo
+            .fetch_ranking_page(&base)
+            .await
+            .expect("fetch_ranking_page");
+        let listed: Vec<(&str, Option<i64>)> = page
+            .items
+            .iter()
+            .filter(|item| symbols.contains(&item.cagr.stock_symbol))
+            .map(|item| (item.cagr.stock_symbol.as_str(), item.rank))
+            .collect();
+        assert_eq!(listed.len(), 4, "資料不足者也必須出現在清單中");
+        // 可算三檔依年化由高至低，且名次遞增；資料不足者 rank 為 None。
+        assert_eq!(listed[0].0, symbols[0]);
+        assert_eq!(listed[1].0, symbols[1]);
+        assert_eq!(listed[2].0, symbols[2]);
+        assert_eq!(listed[3].0, symbols[3]);
+        assert!(listed[3].1.is_none(), "資料不足不得佔名次");
+        let ranks: Vec<i64> = listed[..3].iter().filter_map(|(_, rank)| *rank).collect();
+        assert_eq!(ranks.len(), 3);
+        assert!(ranks[0] < ranks[1] && ranks[1] < ranks[2]);
+        assert_eq!(page.items.len() as i64, page.total.min(base.limit));
+        assert!(page.items.iter().all(|item| !item.name.is_empty()));
+
+        // 產業篩選：名次不得重編，仍是全市場名次。
+        let filtered = repo
+            .fetch_ranking_page(&CagrRankingQuery {
+                industry_id: Some(industry),
+                ..base.clone()
+            })
+            .await
+            .expect("fetch_ranking_page industry");
+        let filtered_ranks: Vec<Option<i64>> = filtered
+            .items
+            .iter()
+            .filter(|item| symbols.contains(&item.cagr.stock_symbol))
+            .map(|item| item.rank)
+            .collect();
+        assert_eq!(
+            filtered_ranks,
+            listed.iter().map(|(_, rank)| *rank).collect::<Vec<_>>(),
+            "套用篩選後名次必須維持全市場名次"
+        );
+        assert!(filtered.total <= page.total);
+        assert_eq!(filtered.coverage, page.coverage, "涵蓋統計不隨畫面篩選變動");
+
+        // 其他產業必然不含這四檔。
+        if let Some(other) = other_industry {
+            let elsewhere = repo
+                .fetch_ranking_page(&CagrRankingQuery {
+                    industry_id: Some(other),
+                    ..base.clone()
+                })
+                .await
+                .expect("fetch_ranking_page other industry");
+            assert!(
+                elsewhere
+                    .items
+                    .iter()
+                    .all(|item| !symbols.contains(&item.cagr.stock_symbol))
+            );
+        }
+
+        // include_incomplete = false 時資料不足者整列消失，total 同步變小。
+        let complete_only = repo
+            .fetch_ranking_page(&CagrRankingQuery {
+                include_incomplete: false,
+                ..base.clone()
+            })
+            .await
+            .expect("fetch_ranking_page complete only");
+        assert!(
+            complete_only
+                .items
+                .iter()
+                .all(|item| item.rank.is_some() && item.cagr.data_complete)
+        );
+        assert!(complete_only.total < page.total);
+
+        // 關鍵字比對代號；分頁位移超出範圍時 total 仍須正確。
+        let keyword = repo
+            .fetch_ranking_page(&CagrRankingQuery {
+                keyword: Some(symbols[0].clone()),
+                ..base.clone()
+            })
+            .await
+            .expect("fetch_ranking_page keyword");
+        assert!(
+            keyword
+                .items
+                .iter()
+                .any(|item| item.cagr.stock_symbol == symbols[0])
+        );
+        let beyond = repo
+            .fetch_ranking_page(&CagrRankingQuery {
+                offset: page.total + 100,
+                ..base.clone()
+            })
+            .await
+            .expect("fetch_ranking_page beyond");
+        assert!(beyond.items.is_empty());
+        assert_eq!(beyond.total, page.total, "位移超界不可讓 total 退化成 0");
+
+        cleanup_borrowed().await;
+    }
+}

--- a/src/infra/database/repository/performance.rs
+++ b/src/infra/database/repository/performance.rs
@@ -625,15 +625,54 @@ mod tests {
         }
     }
 
+    /// 四個假代號，供排行榜測試建立完整母體。
+    fn fake_symbols() -> Vec<String> {
+        vec![
+            FAKE_SYMBOL.to_string(),
+            FAKE_SYMBOL_B.to_string(),
+            FAKE_SYMBOL_C.to_string(),
+            FAKE_SYMBOL_D.to_string(),
+        ]
+    }
+
+    /// 排行榜測試用的產業編號（`stock_industry.sql` 已預先建立 1 與 2）。
+    const TEST_INDUSTRY: i32 = 1;
+    const OTHER_INDUSTRY: i32 = 2;
+
     /// 清理測試寫入的資料列；測試結束務必呼叫，避免污染資料庫。
     async fn cleanup() {
         let _ = sqlx::query("DELETE FROM stock_cagr WHERE stock_symbol = ANY($1)")
-            .bind(vec![
-                FAKE_SYMBOL.to_string(),
-                FAKE_SYMBOL_B.to_string(),
-                FAKE_SYMBOL_C.to_string(),
-                FAKE_SYMBOL_D.to_string(),
-            ])
+            .bind(fake_symbols())
+            .execute(database::get_connection())
+            .await;
+    }
+
+    /// 建立排行榜測試所需的假股票母檔。
+    ///
+    /// 排行榜查詢要 JOIN `stocks` 取名稱與產業，早期版本改為借用資料庫既有的
+    /// 真實代號，但 CI 的測試資料庫只有結構沒有資料，測試因此永遠跳過 ——
+    /// 那些篩選、分頁與名次語意等於從未被驗證。改為自行寫入假代號後，
+    /// 空資料庫也能完整執行，且不會在正式資料的代號上留下痕跡。
+    async fn seed_stocks() {
+        for (index, symbol) in fake_symbols().iter().enumerate() {
+            let _ = sqlx::query(
+                r#"INSERT INTO stocks ("SecurityCode", "Name", stock_symbol, stock_industry_id, "SuspendListing")
+                   VALUES ($1, $2, $1, $3, false)
+                   ON CONFLICT (stock_symbol) DO UPDATE
+                       SET "Name" = excluded."Name", stock_industry_id = excluded.stock_industry_id"#,
+            )
+            .bind(symbol)
+            .bind(format!("測試股{}", index + 1))
+            .bind(TEST_INDUSTRY)
+            .execute(database::get_connection())
+            .await;
+        }
+    }
+
+    /// 移除假股票母檔。
+    async fn cleanup_stocks() {
+        let _ = sqlx::query("DELETE FROM stocks WHERE stock_symbol = ANY($1)")
+            .bind(fake_symbols())
             .execute(database::get_connection())
             .await;
     }
@@ -859,8 +898,8 @@ mod tests {
     ///
     /// 名次必須是「未套用篩選的全市場名次」，因此以產業／關鍵字篩選後，
     /// 同一檔股票的 `rank` 不可改變——這是前端把 rank 當成股票穩定屬性的
-    /// 前提。測試借用 `stocks` 既有的真實代號（唯讀取得）以滿足 JOIN，
-    /// 並只在遠早於本功能上線的 1990-01-02 寫入，結束後一律清除。
+    /// 前提。測試自行寫入四檔假股票以滿足 JOIN，只在遠早於本功能上線的
+    /// 1990-01-02 寫入計算結果，結束後母檔與結果一律清除。
     #[tokio::test]
     #[cfg_attr(
         not(feature = "integration-tests"),
@@ -873,42 +912,16 @@ mod tests {
             return;
         }
 
-        // 排行榜要 JOIN stocks，因此借用真實存在的代號；同產業取三檔以便
-        // 驗證「篩選後名次不重編」。
-        let borrowed: Vec<(String, i32)> = sqlx::query_as(
-            r#"SELECT stock_symbol, stock_industry_id FROM stocks
-               WHERE stock_industry_id = (
-                   SELECT stock_industry_id FROM stocks
-                   GROUP BY stock_industry_id HAVING COUNT(*) >= 4 LIMIT 1
-               )
-               ORDER BY stock_symbol LIMIT 4"#,
-        )
-        .fetch_all(database::get_connection())
-        .await
-        .expect("borrow stocks");
-        if borrowed.len() < 4 {
-            println!("跳過 test_fetch_ranking_page_semantics：stocks 樣本不足");
-            return;
-        }
-        let symbols: Vec<String> = borrowed.iter().map(|(symbol, _)| symbol.clone()).collect();
-        let industry = borrowed[0].1;
-        let other_industry: Option<i32> = sqlx::query_scalar(
-            "SELECT stock_industry_id FROM stocks WHERE stock_industry_id <> $1 LIMIT 1",
-        )
-        .bind(industry)
-        .fetch_optional(database::get_connection())
-        .await
-        .expect("other industry");
+        let symbols = fake_symbols();
+        let industry = TEST_INDUSTRY;
+        let other_industry = Some(OTHER_INDUSTRY);
 
         let cleanup_borrowed = || async {
-            let _ =
-                sqlx::query("DELETE FROM stock_cagr WHERE date = $1 AND stock_symbol = ANY($2)")
-                    .bind(test_date())
-                    .bind(&symbols)
-                    .execute(database::get_connection())
-                    .await;
+            cleanup().await;
+            cleanup_stocks().await;
         };
         cleanup_borrowed().await;
+        seed_stocks().await;
 
         let repo = PgCagrRepository::new();
         // 年化 30 / 20 / 10 三檔可算，第四檔資料不足。

--- a/src/infra/database/table/dividend/mutation.rs
+++ b/src/infra/database/table/dividend/mutation.rs
@@ -318,6 +318,13 @@ mod tests {
             }
         }
 
+        // 假代號的測試資料必須清除，否則會殘留在資料庫裡影響其他查詢。
+        let _ = sqlx::query("DELETE FROM dividend WHERE security_code = $1 AND year = $2")
+            .bind(&e.security_code)
+            .bind(e.year)
+            .execute(database::get_connection())
+            .await;
+
         tracing::debug!("結束 upsert");
     }
 

--- a/src/infra/database/table/mod.rs
+++ b/src/infra/database/table/mod.rs
@@ -6,6 +6,8 @@ pub mod financial;
 pub mod index;
 /// 資金流向與會員市值資料表。
 pub mod money_flow;
+/// 績效指標（每日 CAGR）資料表。
+pub mod performance;
 /// 報價、歷史報價與統計資料表。
 pub mod quote;
 /// 股票主檔。

--- a/src/infra/database/table/performance/mod.rs
+++ b/src/infra/database/table/performance/mod.rs
@@ -1,0 +1,2 @@
+/// 每日 CAGR（固定投入金額的年化報酬）計算結果。
+pub mod stock_cagr;

--- a/src/infra/database/table/performance/stock_cagr.rs
+++ b/src/infra/database/table/performance/stock_cagr.rs
@@ -1,0 +1,289 @@
+use anyhow::{Result, anyhow};
+use chrono::NaiveDate;
+use rust_decimal::Decimal;
+
+use crate::domain::performance::entity::{
+    CagrPeriod, SimulationOutcome, StockCagr as DomainStockCagr,
+};
+
+/// `stock_cagr` 資料表的資料列模型。
+///
+/// 領域層以 `Option<SimulationOutcome>` 包裝三個報酬口徑，資料庫則是平鋪欄位；
+/// 兩者的對應規則：
+/// - `Some(outcome)` → 該口徑各欄位填值。
+/// - `None` → 該口徑各欄位為 `NULL`。
+/// - 讀回時以 `*_end_value` 是否為 `NULL` 判定該口徑是否存在。
+///
+/// 另注意口徑 A（純價格）在資料表中沒有現金欄位——純價格模擬不會產生現金股利，
+/// [`SimulationOutcome::cash_received`] 恆為零，故不浪費一個欄位儲存，
+/// 讀回時直接補零。
+#[derive(sqlx::FromRow, Debug, Clone, PartialEq, Eq)]
+pub struct StockCagr {
+    /// 計算基準日（期末交易日）。
+    pub date: NaiveDate,
+    /// 股票代號。
+    pub stock_symbol: String,
+    /// 統計期間代碼（見 [`CagrPeriod::code`]）。
+    pub period: String,
+    /// 實際採用的期初交易日。
+    pub base_date: Option<NaiveDate>,
+    /// 期初收盤價。
+    pub base_price: Option<Decimal>,
+    /// 期末收盤價。
+    pub end_price: Option<Decimal>,
+    /// 實際年數。
+    pub years: Option<Decimal>,
+    /// 口徑 A：期末持有股數。
+    pub price_end_shares: Option<Decimal>,
+    /// 口徑 A：期末總價值。
+    pub price_end_value: Option<Decimal>,
+    /// 口徑 A：區間總報酬率（%）。
+    pub price_return_pct: Option<Decimal>,
+    /// 口徑 A：年化報酬率（%）。
+    pub price_cagr_pct: Option<Decimal>,
+    /// 口徑 B：期末持有股數。
+    pub total_shares: Option<Decimal>,
+    /// 口徑 B：累積現金股利。
+    pub total_cash: Option<Decimal>,
+    /// 口徑 B：期末總價值。
+    pub total_end_value: Option<Decimal>,
+    /// 口徑 B：區間總報酬率（%）。
+    pub total_return_pct: Option<Decimal>,
+    /// 口徑 B：年化報酬率（%）。
+    pub total_cagr_pct: Option<Decimal>,
+    /// 口徑 C：期末持有股數。
+    pub reinv_shares: Option<Decimal>,
+    /// 口徑 C：剩餘現金。
+    pub reinv_cash: Option<Decimal>,
+    /// 口徑 C：期末總價值。
+    pub reinv_end_value: Option<Decimal>,
+    /// 口徑 C：區間總報酬率（%）。
+    pub reinv_return_pct: Option<Decimal>,
+    /// 口徑 C：年化報酬率（%）。
+    pub reinv_cagr_pct: Option<Decimal>,
+    /// 該股最早的報價日。
+    pub first_quote_date: Option<NaiveDate>,
+    /// 期初日順延天數。
+    pub shortfall_days: Option<i32>,
+    /// 期初資料是否齊全。
+    pub data_complete: bool,
+    /// 是否偵測到疑似減資或分割的異常跳動。
+    pub has_anomaly: bool,
+    /// 期間內採計的除權息次數。
+    pub dividend_events: i32,
+}
+
+/// 單一口徑攤平後的資料庫欄位：（股數, 現金, 期末價值, 區間總報酬率, 年化報酬率）。
+type FlatOutcome = (
+    Option<Decimal>,
+    Option<Decimal>,
+    Option<Decimal>,
+    Option<Decimal>,
+    Option<Decimal>,
+);
+
+/// 將單一口徑的模擬結果攤平成資料庫欄位。
+///
+/// `None` 時全部為 `None`，讓資料庫維持 `NULL`——以 0 代替會讓
+/// 「資料不足」被誤讀成「零報酬」。
+fn flatten_outcome(outcome: Option<SimulationOutcome>) -> FlatOutcome {
+    match outcome {
+        Some(o) => (
+            Some(o.end_shares),
+            Some(o.cash_received),
+            Some(o.end_value),
+            Some(o.total_return_pct),
+            Some(o.cagr_pct),
+        ),
+        None => (None, None, None, None, None),
+    }
+}
+
+/// 由攤平欄位還原單一口徑的模擬結果。
+///
+/// 以 `end_value` 是否存在作為該口徑存在與否的判準；其餘欄位若因舊資料
+/// 而缺漏則補零，避免整列讀取失敗。
+fn restore_outcome(
+    end_shares: Option<Decimal>,
+    cash_received: Option<Decimal>,
+    end_value: Option<Decimal>,
+    total_return_pct: Option<Decimal>,
+    cagr_pct: Option<Decimal>,
+) -> Option<SimulationOutcome> {
+    end_value.map(|value| SimulationOutcome {
+        end_shares: end_shares.unwrap_or_default(),
+        cash_received: cash_received.unwrap_or_default(),
+        end_value: value,
+        total_return_pct: total_return_pct.unwrap_or_default(),
+        cagr_pct: cagr_pct.unwrap_or_default(),
+    })
+}
+
+impl From<&DomainStockCagr> for StockCagr {
+    fn from(domain: &DomainStockCagr) -> Self {
+        let (price_end_shares, _price_cash, price_end_value, price_return_pct, price_cagr_pct) =
+            flatten_outcome(domain.price);
+        let (total_shares, total_cash, total_end_value, total_return_pct, total_cagr_pct) =
+            flatten_outcome(domain.total);
+        let (reinv_shares, reinv_cash, reinv_end_value, reinv_return_pct, reinv_cagr_pct) =
+            flatten_outcome(domain.reinvested);
+
+        StockCagr {
+            date: domain.date,
+            stock_symbol: domain.stock_symbol.clone(),
+            period: domain.period.code().to_string(),
+            base_date: domain.base_date,
+            base_price: domain.base_price,
+            end_price: domain.end_price,
+            years: domain.years,
+            price_end_shares,
+            price_end_value,
+            price_return_pct,
+            price_cagr_pct,
+            total_shares,
+            total_cash,
+            total_end_value,
+            total_return_pct,
+            total_cagr_pct,
+            reinv_shares,
+            reinv_cash,
+            reinv_end_value,
+            reinv_return_pct,
+            reinv_cagr_pct,
+            first_quote_date: domain.first_quote_date,
+            shortfall_days: domain.shortfall_days,
+            data_complete: domain.data_complete,
+            has_anomaly: domain.has_anomaly,
+            dividend_events: domain.dividend_events,
+        }
+    }
+}
+
+impl StockCagr {
+    /// 還原為領域實體。
+    ///
+    /// # Errors
+    /// 當 `period` 欄位不是已知的期間代碼時回傳錯誤（代表資料表被寫入了
+    /// 程式無法解釋的值，靜默忽略會讓排行榜少掉整個期間而難以察覺）。
+    pub fn to_domain(&self) -> Result<DomainStockCagr> {
+        let period = CagrPeriod::from_code(&self.period)
+            .ok_or_else(|| anyhow!("無法辨識的 stock_cagr.period 代碼：{}", self.period))?;
+
+        Ok(DomainStockCagr {
+            date: self.date,
+            stock_symbol: self.stock_symbol.clone(),
+            period,
+            base_date: self.base_date,
+            base_price: self.base_price,
+            end_price: self.end_price,
+            years: self.years,
+            // 口徑 A 無現金欄位，現金固定補零。
+            price: restore_outcome(
+                self.price_end_shares,
+                Some(Decimal::ZERO),
+                self.price_end_value,
+                self.price_return_pct,
+                self.price_cagr_pct,
+            ),
+            total: restore_outcome(
+                self.total_shares,
+                self.total_cash,
+                self.total_end_value,
+                self.total_return_pct,
+                self.total_cagr_pct,
+            ),
+            reinvested: restore_outcome(
+                self.reinv_shares,
+                self.reinv_cash,
+                self.reinv_end_value,
+                self.reinv_return_pct,
+                self.reinv_cagr_pct,
+            ),
+            first_quote_date: self.first_quote_date,
+            shortfall_days: self.shortfall_days,
+            data_complete: self.data_complete,
+            has_anomaly: self.has_anomaly,
+            dividend_events: self.dividend_events,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    fn sample_outcome() -> SimulationOutcome {
+        SimulationOutcome {
+            end_shares: dec!(123.45678),
+            cash_received: dec!(321.5),
+            end_value: dec!(12345.6789),
+            total_return_pct: dec!(23.4567),
+            cagr_pct: dec!(7.8901),
+        }
+    }
+
+    fn sample_domain() -> DomainStockCagr {
+        DomainStockCagr {
+            date: NaiveDate::from_ymd_opt(2026, 6, 30).unwrap(),
+            stock_symbol: "2330".to_string(),
+            period: CagrPeriod::Y3,
+            base_date: NaiveDate::from_ymd_opt(2023, 6, 30),
+            base_price: Some(dec!(560.0)),
+            end_price: Some(dec!(1000.0)),
+            years: Some(dec!(3.001)),
+            price: Some(sample_outcome()),
+            total: Some(sample_outcome()),
+            reinvested: None,
+            first_quote_date: NaiveDate::from_ymd_opt(2000, 1, 4),
+            shortfall_days: Some(0),
+            data_complete: true,
+            has_anomaly: false,
+            dividend_events: 12,
+        }
+    }
+
+    #[test]
+    fn test_round_trip_keeps_values() {
+        let domain = sample_domain();
+        let row = StockCagr::from(&domain);
+        let restored = row.to_domain().expect("期間代碼應可還原");
+
+        // 口徑 A 的現金不落庫，還原時補零，故先個別比對再比其餘欄位。
+        assert_eq!(restored.price.map(|o| o.cash_received), Some(Decimal::ZERO));
+        assert_eq!(restored.total, domain.total);
+        assert_eq!(restored.reinvested, None);
+        assert_eq!(restored.date, domain.date);
+        assert_eq!(restored.period, domain.period);
+        assert_eq!(restored.years, domain.years);
+        assert_eq!(restored.dividend_events, domain.dividend_events);
+    }
+
+    #[test]
+    fn test_incomplete_row_maps_to_none() {
+        let mut domain = sample_domain();
+        domain.data_complete = false;
+        domain.price = None;
+        domain.total = None;
+        domain.reinvested = None;
+        domain.base_price = None;
+        domain.years = None;
+
+        let row = StockCagr::from(&domain);
+        assert!(row.total_end_value.is_none());
+        assert!(row.price_cagr_pct.is_none());
+
+        let restored = row.to_domain().expect("期間代碼應可還原");
+        assert!(restored.price.is_none());
+        assert!(restored.total.is_none());
+        assert!(restored.reinvested.is_none());
+        assert!(!restored.data_complete);
+    }
+
+    #[test]
+    fn test_unknown_period_code_is_error() {
+        let mut row = StockCagr::from(&sample_domain());
+        row.period = "Z9".to_string();
+        assert!(row.to_domain().is_err());
+    }
+}

--- a/src/interfaces/web/data_api/dto.rs
+++ b/src/interfaces/web/data_api/dto.rs
@@ -130,6 +130,8 @@ enum CagrPeriodParamValue {
     Y3,
     /// 5 年。
     Y5,
+    /// 7 年。
+    Y7,
     /// 10 年。
     Y10,
 }
@@ -990,7 +992,7 @@ pub(super) struct StockScreeningParams {
 /// handler 內以固定訊息回 422，而非交給 serde 產生泛用錯誤。
 #[derive(Debug, Deserialize, IntoParams)]
 pub(super) struct CagrRankingParams {
-    /// 統計期間：`M3`、`M6`、`Y1`（預設）、`Y1H`、`Y2`、`Y3`、`Y5` 或 `Y10`。
+    /// 統計期間：`M3`、`M6`、`Y1`（預設）、`Y1H`、`Y2`、`Y3`、`Y5`、`Y7` 或 `Y10`。
     #[param(value_type = CagrPeriodParamValue, inline, default = "Y1")]
     pub(super) period: Option<String>,
     /// 報酬口徑：`price`、`total`（預設）或 `reinvested`。

--- a/src/interfaces/web/data_api/dto.rs
+++ b/src/interfaces/web/data_api/dto.rs
@@ -109,6 +109,55 @@ enum SortOrderParamValue {
     Desc,
 }
 
+/// OpenAPI 文件使用的 CAGR 統計期間。
+///
+/// 值與 `CagrPeriod::code()` 一一對應；runtime 仍以 `String` 解析，
+/// 讓不合法的值得到明確的 422 訊息而非 serde 的泛用錯誤。
+#[derive(ToSchema)]
+#[allow(dead_code)] // 此 enum 僅提供 OpenAPI schema。
+enum CagrPeriodParamValue {
+    /// 3 個月。
+    M3,
+    /// 6 個月。
+    M6,
+    /// 1 年。
+    Y1,
+    /// 1 年 6 個月。
+    Y1H,
+    /// 2 年。
+    Y2,
+    /// 3 年。
+    Y3,
+    /// 5 年。
+    Y5,
+    /// 10 年。
+    Y10,
+}
+
+/// OpenAPI 文件使用的 CAGR 報酬口徑。
+#[derive(ToSchema)]
+#[schema(rename_all = "snake_case")]
+#[allow(dead_code)] // 此 enum 僅提供 OpenAPI schema。
+enum CagrMetricParamValue {
+    /// 口徑 A：純價格報酬（長期間不提供）。
+    Price,
+    /// 口徑 B：含息不再投入，主指標。
+    Total,
+    /// 口徑 C：含息再投入。
+    Reinvested,
+}
+
+/// OpenAPI 文件使用的 CAGR 排行排序鍵。
+#[derive(ToSchema)]
+#[schema(rename_all = "snake_case")]
+#[allow(dead_code)] // 此 enum 僅提供 OpenAPI schema。
+enum CagrSortParamValue {
+    /// 依年化報酬率排序。
+    Cagr,
+    /// 依區間總報酬率排序。
+    TotalReturn,
+}
+
 /// 股票基本資料。
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub(super) struct Stock {
@@ -933,4 +982,223 @@ pub(super) struct StockScreeningParams {
     /// 最多回傳筆數，預設 20，範圍 1–50。
     #[param(minimum = 1, maximum = 50, default = 20)]
     pub(super) limit: Option<u8>,
+}
+
+/// 每日 CAGR 排行 endpoint 的 query string。
+///
+/// 參數名與前端 `stock_go` 送出的完全一致，勿更名；不合法的值一律在
+/// handler 內以固定訊息回 422，而非交給 serde 產生泛用錯誤。
+#[derive(Debug, Deserialize, IntoParams)]
+pub(super) struct CagrRankingParams {
+    /// 統計期間：`M3`、`M6`、`Y1`（預設）、`Y1H`、`Y2`、`Y3`、`Y5` 或 `Y10`。
+    #[param(value_type = CagrPeriodParamValue, inline, default = "Y1")]
+    pub(super) period: Option<String>,
+    /// 報酬口徑：`price`、`total`（預設）或 `reinvested`。
+    ///
+    /// `Y5`／`Y10` 不接受 `price`——近十年每年皆有 134–216 檔股票配股，
+    /// 長期間忽略配股的誤差顯著，因此回 422 而非默默給出低估的數字。
+    #[param(value_type = CagrMetricParamValue, inline, default = "total")]
+    pub(super) metric: Option<String>,
+    /// 排序鍵：`cagr` 或 `total_return`；未指定時依期間長度自動選擇
+    /// （12 個月以上用 `cagr`，短期間用 `total_return`）。
+    #[param(value_type = CagrSortParamValue, inline)]
+    pub(super) sort: Option<String>,
+    /// 市場：`all`（預設）、`twse`、`tpex`，或直接給市場編號。
+    #[param(default = "all")]
+    pub(super) market: Option<String>,
+    /// 可選的正整數產業分類編號。
+    #[param(minimum = 1)]
+    pub(super) stock_industry_id: Option<i32>,
+    /// 代號或名稱關鍵字（模糊比對），長度 1–50。
+    pub(super) keyword: Option<String>,
+    /// 是否一併回傳資料不足的項目，預設 `true`。
+    ///
+    /// 預設帶回是刻意的：「查得到但算不出來」與「查不到」是兩件不同的事。
+    #[param(default = true)]
+    pub(super) include_incomplete: Option<bool>,
+    /// 最多回傳筆數，預設 50，範圍 1–200。
+    #[param(minimum = 1, maximum = 200, default = 50)]
+    pub(super) limit: Option<u16>,
+    /// 起始位移，預設 0。
+    #[param(minimum = 0, default = 0)]
+    pub(super) offset: Option<u32>,
+    /// 計算基準日，格式 `YYYY-MM-DD`；未提供時取最新一個已完成計算的日期。
+    pub(super) date: Option<String>,
+}
+
+/// 個股 CAGR 全期間 endpoint 的 query string。
+#[derive(Debug, Deserialize, IntoParams)]
+pub(super) struct CagrSymbolParams {
+    /// 報酬口徑：`price`、`total`（預設）或 `reinvested`。
+    #[param(value_type = CagrMetricParamValue, inline, default = "total")]
+    pub(super) metric: Option<String>,
+    /// 計算基準日，格式 `YYYY-MM-DD`；未提供時取最新一個已完成計算的日期。
+    pub(super) date: Option<String>,
+}
+
+/// CAGR 樣本涵蓋統計。
+///
+/// `coverage_ratio` 的分母是母體檔數（`universe`），用來揭露長期間的樣本
+/// 缺口；`summary.positive_ratio` 的分母則是可算檔數（`counted`），兩者
+/// 分母不同，混用會安靜地得到偏低的數字。
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub(super) struct CagrCoverageInfo {
+    /// 母體檔數（該基準日與期間寫入的全部資料列）。
+    pub(super) universe: i64,
+    /// 實際可算檔數。
+    pub(super) counted: i64,
+    /// 樣本涵蓋率＝`counted / universe`，字串固定四位小數。
+    pub(super) coverage_ratio: String,
+    /// 資料不足檔數。
+    pub(super) incomplete: i64,
+    /// 標記為疑似減資／分割的檔數。
+    pub(super) anomaly_flagged: i64,
+    /// 是否需要顯示存活者偏誤揭露條（Y5／Y10 為 `true`）。
+    pub(super) survivorship_note: bool,
+}
+
+/// CAGR 排行的正報酬摘要。
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub(super) struct CagrSummary {
+    /// 可算檔數中報酬為正的檔數。
+    pub(super) positive: i64,
+    /// 正報酬比例＝`positive / counted`，字串固定四位小數。
+    pub(super) positive_ratio: String,
+}
+
+/// CAGR 排行中的單一股票。
+///
+/// 所有金額與比率一律序列化為字串：後端是 `rust_decimal`，轉成 JSON number
+/// 會經過 f64 而掉精度。資料不足的項目仍會出現在清單中，只是各數值欄位為
+/// `null`——前端據此渲染灰化列，而不是把它當成不存在的股票。
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub(super) struct CagrRankingItem {
+    /// 全市場名次；資料不足者為 `null` 且不佔名次。
+    ///
+    /// 名次是該 `(date, period, metric)` 之下**未套用篩選**的完整市場排名，
+    /// 因此篩選單一產業後可能看到 1、17、43 這種不連續的值——這是刻意的：
+    /// 篩選後的「第 1 名」不是市場第 1 名，重新編號會誤導使用者。
+    pub(super) rank: Option<i64>,
+    /// 股票代號。
+    pub(super) stock_symbol: String,
+    /// 股票名稱。
+    pub(super) name: String,
+    /// 產業分類編號。
+    pub(super) stock_industry_id: i32,
+    /// 實際採用的期初交易日，格式 `YYYY-MM-DD`。
+    pub(super) base_date: Option<String>,
+    /// 該股最早的報價日，格式 `YYYY-MM-DD`。
+    pub(super) first_quote_date: Option<String>,
+    /// 期初日較名目期初目標日順延的天數；0 表完全對齊。
+    pub(super) shortfall_days: Option<i32>,
+    /// 期初收盤價。
+    pub(super) base_price: Option<String>,
+    /// 期末收盤價。
+    pub(super) end_price: Option<String>,
+    /// 期末持有股數（含配股）。
+    pub(super) end_shares: Option<String>,
+    /// 累積現金股利。
+    pub(super) cash_received: Option<String>,
+    /// 期末總價值。
+    pub(super) end_value: Option<String>,
+    /// 區間總報酬率（%）。
+    pub(super) total_return_pct: Option<String>,
+    /// 年化報酬率（%）。
+    pub(super) cagr_pct: Option<String>,
+    /// 期間內實際採計的除權息次數。
+    pub(super) dividend_events: i32,
+    /// 期初資料是否齊全。
+    pub(super) data_complete: bool,
+    /// 是否偵測到無對應除權息的異常跳動（疑似減資或分割）。
+    pub(super) has_anomaly: bool,
+}
+
+/// 個股 CAGR 的單一期間結果。
+///
+/// 欄位與 [`CagrRankingItem`] 相同，但多一個 `period`、沒有 `rank`——
+/// 個股頁是「同一檔股票的八個期間」，名次在此沒有意義。
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub(super) struct CagrPeriodItem {
+    /// 統計期間代碼。
+    pub(super) period: String,
+    /// 股票代號。
+    pub(super) stock_symbol: String,
+    /// 股票名稱。
+    pub(super) name: String,
+    /// 產業分類編號。
+    pub(super) stock_industry_id: i32,
+    /// 實際採用的期初交易日，格式 `YYYY-MM-DD`。
+    pub(super) base_date: Option<String>,
+    /// 該股最早的報價日，格式 `YYYY-MM-DD`。
+    pub(super) first_quote_date: Option<String>,
+    /// 期初日較名目期初目標日順延的天數。
+    pub(super) shortfall_days: Option<i32>,
+    /// 期初收盤價。
+    pub(super) base_price: Option<String>,
+    /// 期末收盤價。
+    pub(super) end_price: Option<String>,
+    /// 期末持有股數（含配股）。
+    pub(super) end_shares: Option<String>,
+    /// 累積現金股利。
+    pub(super) cash_received: Option<String>,
+    /// 期末總價值。
+    pub(super) end_value: Option<String>,
+    /// 區間總報酬率（%）。
+    pub(super) total_return_pct: Option<String>,
+    /// 年化報酬率（%）。
+    pub(super) cagr_pct: Option<String>,
+    /// 實際年數＝（期末交易日 − 期初交易日）／365。
+    pub(super) years: Option<String>,
+    /// 期間內實際採計的除權息次數。
+    pub(super) dividend_events: i32,
+    /// 期初資料是否齊全。
+    pub(super) data_complete: bool,
+    /// 是否偵測到疑似減資或分割的異常跳動。
+    pub(super) has_anomaly: bool,
+    /// 該期間是否需要顯示存活者偏誤揭露條。
+    pub(super) survivorship_note: bool,
+}
+
+/// CAGR 排行的成功回應。
+#[derive(Debug, Serialize, ToSchema)]
+pub(super) struct CagrRankingResponse {
+    /// 統計期間代碼。
+    pub(super) period: String,
+    /// 報酬口徑代碼。
+    pub(super) metric: String,
+    /// 實際採用的排序鍵代碼。
+    pub(super) sort: String,
+    /// 計算基準日，格式 `YYYY-MM-DD`。
+    pub(super) date: String,
+    /// 本頁可算項目中最常見的期初交易日；全部資料不足時為 `null`。
+    pub(super) base_date: Option<String>,
+    /// 對應 `base_date` 的實際年數，字串固定四位小數。
+    pub(super) years: Option<String>,
+    /// 固定投入金額（元）。整數，維持 JSON number。
+    pub(super) principal: i64,
+    /// 符合篩選條件的總筆數，供分頁計算。
+    pub(super) total: i64,
+    /// 樣本涵蓋統計（不受畫面篩選影響）。
+    pub(super) coverage: CagrCoverageInfo,
+    /// 正報酬摘要。
+    pub(super) summary: CagrSummary,
+    /// 本頁項目；可算項目在前依排序鍵由高到低，資料不足者殿後。
+    pub(super) items: Vec<CagrRankingItem>,
+}
+
+/// 個股 CAGR 全期間的成功回應。
+#[derive(Debug, Serialize, ToSchema)]
+pub(super) struct CagrSymbolResponse {
+    /// 股票代號。
+    pub(super) stock_symbol: String,
+    /// 股票名稱。
+    pub(super) name: Option<String>,
+    /// 報酬口徑代碼。
+    pub(super) metric: String,
+    /// 計算基準日，格式 `YYYY-MM-DD`。
+    pub(super) date: String,
+    /// 固定投入金額（元）。
+    pub(super) principal: i64,
+    /// 全部八個期間，依期間長度由短至長；含資料不足者。
+    pub(super) items: Vec<CagrPeriodItem>,
 }

--- a/src/interfaces/web/data_api/handlers.rs
+++ b/src/interfaces/web/data_api/handlers.rs
@@ -14,8 +14,10 @@ use rust_decimal::Decimal;
 use std::str::FromStr;
 
 use super::dto::{
-    DailyQuote, Dividend, DividendCalendarEvent, DividendCalendarParams, DividendCalendarResponse,
-    DividendHistoryParams, DividendHistoryResponse, DividendYieldRank, DividendYieldRankingParams,
+    CagrCoverageInfo, CagrPeriodItem, CagrRankingItem, CagrRankingParams, CagrRankingResponse,
+    CagrSummary, CagrSymbolParams, CagrSymbolResponse, DailyQuote, Dividend, DividendCalendarEvent,
+    DividendCalendarParams, DividendCalendarResponse, DividendHistoryParams,
+    DividendHistoryResponse, DividendYieldRank, DividendYieldRankingParams,
     DividendYieldRankingResponse, ErrorBody, FinancialStatement, FinancialStatementHistoryResponse,
     HealthResponse, HistoricalQuote, HistoryParams, LatestQuoteResponse, MarketBreadth,
     MarketBreadthParams, MarketBreadthResponse, MarketIndexHistoryParams,
@@ -26,6 +28,14 @@ use super::dto::{
     StockScreeningParams, StockScreeningResponse, StockValuation, StockValuationResponse,
     ValuationParams,
 };
+use crate::domain::performance::entity::{
+    CagrMetric, CagrPeriod, PRINCIPAL, SimulationOutcome, StockCagr as DomainStockCagr,
+};
+use crate::domain::performance::query::{
+    CagrRankingItem as DomainCagrRankingItem, CagrRankingQuery, CagrSortKey,
+};
+use crate::domain::performance::repository::CagrRepository;
+use crate::infra::database::repository::performance::PgCagrRepository;
 use crate::infra::{cache::SHARE, database};
 
 /// 產生不含內部實作細節的統一 JSON 錯誤回應。
@@ -2119,6 +2129,366 @@ impl From<ProfileRow> for StockProfile {
     }
 }
 
+/// 每日 CAGR 排行（M4）。
+///
+/// 以固定投入 [`PRINCIPAL`] 元模擬各期間、各口徑的報酬，回傳單頁排行、
+/// 分頁總筆數與樣本涵蓋統計。三個設計取捨值得注意：
+///
+/// - **所有金額與比率序列化為字串**：後端是 `rust_decimal`，轉成 JSON
+///   number 會經過 f64 而掉精度；`principal` 與各種計數是整數，維持 number。
+/// - **資料不足的項目回傳 `null` 而非從 `items` 省略**：「查得到但算不出來」
+///   與「查不到」是兩件不同的事，前端據此渲染灰化列。
+/// - **長期間不提供純價格口徑**：`Y5`／`Y10` 搭配 `metric=price` 回 422。
+///
+/// # Errors
+///
+/// 參數不合法或長期間要求純價格口徑回 422；整張表尚無計算結果回 404；
+/// 驗證失敗回 401；倉儲查詢失敗時記錄內部錯誤並回不含 SQL 細節的 500。
+#[utoipa::path(get, path = "/api/v1/market/cagr-ranking", tag = "data-api", params(CagrRankingParams), responses((status = 200, body = CagrRankingResponse), (status = 401, body = ErrorBody), (status = 404, body = ErrorBody), (status = 422, body = ErrorBody), (status = 500, body = ErrorBody)), security(("bearer_auth" = [])))]
+pub(super) async fn cagr_ranking(Query(params): Query<CagrRankingParams>) -> Response {
+    let period = match parse_cagr_period(params.period.as_deref()) {
+        Ok(value) => value,
+        Err(message) => return error_response(StatusCode::UNPROCESSABLE_ENTITY, message),
+    };
+    let metric = match parse_cagr_metric(params.metric.as_deref()) {
+        Ok(value) => value,
+        Err(message) => return error_response(StatusCode::UNPROCESSABLE_ENTITY, message),
+    };
+    // 由領域層判定，不在此硬寫期間清單——判準改變時只需改一處。
+    if metric == CagrMetric::Price && !period.supports_price_metric() {
+        return error_response(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "長期間不提供純價格口徑：近十年每年皆有 134–216 檔股票配股,\
+             忽略配股在長期間的低估幅度顯著,請改用 total 或 reinvested",
+        );
+    }
+    let sort = match params.sort.as_deref() {
+        // 未指定時依期間長度決定：短期間年化會被放大約四倍，統計意義薄弱。
+        None => CagrSortKey::default_for(period),
+        Some(code) => match CagrSortKey::from_code(code) {
+            Some(value) => value,
+            None => {
+                return error_response(
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "sort 必須為 cagr 或 total_return",
+                );
+            }
+        },
+    };
+    let market_id = match cagr_market_id(params.market.as_deref().unwrap_or("all")) {
+        Ok(value) => value,
+        Err(message) => return error_response(StatusCode::UNPROCESSABLE_ENTITY, message),
+    };
+    if params.stock_industry_id.is_some_and(|value| value <= 0) {
+        return error_response(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "stock_industry_id 必須為正整數",
+        );
+    }
+    let keyword = match normalize_cagr_keyword(params.keyword.as_deref()) {
+        Ok(value) => value,
+        Err(message) => return error_response(StatusCode::UNPROCESSABLE_ENTITY, message),
+    };
+    let limit = params.limit.unwrap_or(50);
+    if !(1..=200).contains(&limit) {
+        return error_response(StatusCode::UNPROCESSABLE_ENTITY, "limit 必須介於 1 至 200");
+    }
+    let offset = params.offset.unwrap_or(0);
+    let date = match parse_optional_date(params.date.as_deref()) {
+        Ok(value) => value,
+        Err(message) => return error_response(StatusCode::UNPROCESSABLE_ENTITY, message),
+    };
+
+    let repository = PgCagrRepository::new();
+    let date = match resolve_cagr_date(&repository, date).await {
+        Ok(Some(value)) => value,
+        Ok(None) => return error_response(StatusCode::NOT_FOUND, "查無 CAGR 計算結果"),
+        Err(error) => return repository_error(error),
+    };
+
+    let query = CagrRankingQuery {
+        date,
+        period,
+        metric,
+        sort,
+        market_id,
+        industry_id: params.stock_industry_id,
+        keyword,
+        include_incomplete: params.include_incomplete.unwrap_or(true),
+        limit: i64::from(limit),
+        offset: i64::from(offset),
+    };
+    let page = match repository.fetch_ranking_page(&query).await {
+        Ok(value) => value,
+        Err(error) => return repository_error(error),
+    };
+
+    // 表頭的期初日／年數取本頁可算項目中最常見者：同一基準日的絕大多數
+    // 股票會對齊到同一個交易日，少數因停牌順延的個股不應決定表頭。
+    let base_date = representative_base_date(&page.items);
+    let years = base_date.and_then(|target| {
+        page.items
+            .iter()
+            .find(|item| item.cagr.data_complete && item.cagr.base_date == Some(target))
+            .and_then(|item| item.cagr.years)
+    });
+
+    Json(CagrRankingResponse {
+        period: period.code().to_owned(),
+        metric: metric.code().to_owned(),
+        sort: sort.code().to_owned(),
+        date: date.to_string(),
+        base_date: base_date.map(|value| value.to_string()),
+        years: decimal_ratio(years),
+        principal: PRINCIPAL,
+        total: page.total,
+        coverage: CagrCoverageInfo {
+            universe: page.coverage.universe,
+            counted: page.coverage.counted,
+            coverage_ratio: format!("{:.4}", page.coverage.coverage_ratio()),
+            incomplete: page.coverage.incomplete,
+            anomaly_flagged: page.coverage.anomaly_flagged,
+            survivorship_note: period.requires_coverage_disclosure(),
+        },
+        summary: CagrSummary {
+            positive: page.coverage.positive,
+            // 分母是可算檔數而非母體，直接取領域方法避免各處各算一份。
+            positive_ratio: format!("{:.4}", page.coverage.positive_ratio()),
+        },
+        items: page
+            .items
+            .into_iter()
+            .map(|item| cagr_ranking_item(item, metric))
+            .collect(),
+    })
+    .into_response()
+}
+
+/// 單一個股在指定基準日的全部八個期間 CAGR（M4）。
+///
+/// 與排行不同，這裡一律回傳全部期間（含資料不足者），讓個股頁能同時呈現
+/// 「三個月」到「十年」的完整輪廓；資料不足的期間各數值欄位為 `null`。
+///
+/// # Errors
+///
+/// `metric` 或 `date` 不合法回 422；未知代號或該股該日無計算結果回 404；
+/// 驗證失敗回 401；倉儲查詢失敗回不含 SQL 細節的 500。
+#[utoipa::path(get, path = "/api/v1/market/cagr-ranking/{stock_symbol}", tag = "data-api", params(("stock_symbol" = String, Path, description = "股票代號"), CagrSymbolParams), responses((status = 200, body = CagrSymbolResponse), (status = 401, body = ErrorBody), (status = 404, body = ErrorBody), (status = 422, body = ErrorBody), (status = 500, body = ErrorBody)), security(("bearer_auth" = [])))]
+pub(super) async fn cagr_by_symbol(
+    Path(stock_symbol): Path<String>,
+    Query(params): Query<CagrSymbolParams>,
+) -> Response {
+    let metric = match parse_cagr_metric(params.metric.as_deref()) {
+        Ok(value) => value,
+        Err(message) => return error_response(StatusCode::UNPROCESSABLE_ENTITY, message),
+    };
+    let date = match parse_optional_date(params.date.as_deref()) {
+        Ok(value) => value,
+        Err(message) => return error_response(StatusCode::UNPROCESSABLE_ENTITY, message),
+    };
+
+    // 先確認代號存在，讓「代號打錯」與「這檔股票尚未計算」都是 404 但訊息不同。
+    let profile: Result<Option<(String, i32)>, _> =
+        sqlx::query_as(r#"SELECT "Name", stock_industry_id FROM stocks WHERE stock_symbol = $1"#)
+            .bind(&stock_symbol)
+            .fetch_optional(database::get_connection())
+            .await;
+    let (name, industry_id) = match profile {
+        Ok(Some(value)) => value,
+        Ok(None) => return error_response(StatusCode::NOT_FOUND, "找不到股票代號"),
+        Err(error) => return database_error(error),
+    };
+
+    let repository = PgCagrRepository::new();
+    let date = match resolve_cagr_date(&repository, date).await {
+        Ok(Some(value)) => value,
+        Ok(None) => return error_response(StatusCode::NOT_FOUND, "查無 CAGR 計算結果"),
+        Err(error) => return repository_error(error),
+    };
+    let records = match repository.fetch_by_symbol(date, &stock_symbol).await {
+        Ok(value) => value,
+        Err(error) => return repository_error(error),
+    };
+    if records.is_empty() {
+        return error_response(StatusCode::NOT_FOUND, "查無此股票的 CAGR 計算結果");
+    }
+
+    Json(CagrSymbolResponse {
+        stock_symbol,
+        name: Some(name.clone()),
+        metric: metric.code().to_owned(),
+        date: date.to_string(),
+        principal: PRINCIPAL,
+        items: records
+            .into_iter()
+            .map(|record| cagr_period_item(record, &name, industry_id, metric))
+            .collect(),
+    })
+    .into_response()
+}
+
+/// 解析 `period` 查詢參數；未提供時預設 `Y1`。
+fn parse_cagr_period(value: Option<&str>) -> Result<CagrPeriod, &'static str> {
+    CagrPeriod::from_code(value.unwrap_or("Y1"))
+        .ok_or("period 必須為 M3、M6、Y1、Y1H、Y2、Y3、Y5 或 Y10")
+}
+
+/// 解析 `metric` 查詢參數；未提供時預設主指標 `total`。
+fn parse_cagr_metric(value: Option<&str>) -> Result<CagrMetric, &'static str> {
+    CagrMetric::from_code(value.unwrap_or("total"))
+        .ok_or("metric 必須為 price、total 或 reinvested")
+}
+
+/// 將 `market` 參數轉成倉儲層的市場編號篩選。
+///
+/// 與其他排行 endpoint 不同，`all` 在此是「不篩選」（`None`）而非展開成
+/// `IN (2, 4)`：CAGR 的母體與涵蓋率統計以整個 `(基準日, 期間)` 為範圍，
+/// 若這裡偷偷縮小集合，畫面上的檔數就對不上 `coverage.universe`。
+/// 除三個代號外亦接受市場編號，供前端直接指定興櫃等其他市場。
+fn cagr_market_id(market: &str) -> Result<Option<i32>, &'static str> {
+    match market {
+        "all" => Ok(None),
+        "twse" => Ok(Some(2)),
+        "tpex" => Ok(Some(4)),
+        other => other
+            .parse::<i32>()
+            .ok()
+            .filter(|value| *value > 0)
+            .map(Some)
+            .ok_or("market 必須為 all、twse、tpex 或正整數市場編號"),
+    }
+}
+
+/// 正規化關鍵字：去除前後空白，空字串視為未指定。
+fn normalize_cagr_keyword(keyword: Option<&str>) -> Result<Option<String>, &'static str> {
+    let Some(trimmed) = keyword.map(str::trim) else {
+        return Ok(None);
+    };
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    if trimmed.chars().count() > 50 {
+        return Err("keyword 長度必須介於 1 至 50 字元");
+    }
+    Ok(Some(trimmed.to_owned()))
+}
+
+/// 決定實際查詢的基準日：未指定時取最新一個已完成計算的日期。
+async fn resolve_cagr_date(
+    repository: &PgCagrRepository,
+    date: Option<NaiveDate>,
+) -> anyhow::Result<Option<NaiveDate>> {
+    match date {
+        Some(value) => Ok(Some(value)),
+        None => repository.fetch_latest_date().await,
+    }
+}
+
+/// 取出指定口徑的模擬結果；該口徑不可算時為 `None`。
+fn cagr_outcome(record: &DomainStockCagr, metric: CagrMetric) -> Option<SimulationOutcome> {
+    match metric {
+        CagrMetric::Price => record.price,
+        CagrMetric::Total => record.total,
+        CagrMetric::Reinvested => record.reinvested,
+    }
+}
+
+/// 將金額或比率序列化為固定四位小數的字串。
+///
+/// 一律走字串是刻意的：`rust_decimal` 轉 JSON number 會經過 f64，
+/// 十年期的期末總值在 f64 下會出現尾數漂移。
+fn decimal_ratio(value: Option<Decimal>) -> Option<String> {
+    value.map(|number| format!("{number:.4}"))
+}
+
+/// 將股數序列化為固定八位小數的字串（配股會產生零股）。
+fn decimal_shares(value: Option<Decimal>) -> Option<String> {
+    value.map(|number| format!("{number:.8}"))
+}
+
+/// 將排行榜的領域項目轉成 API DTO。
+fn cagr_ranking_item(item: DomainCagrRankingItem, metric: CagrMetric) -> CagrRankingItem {
+    let outcome = cagr_outcome(&item.cagr, metric);
+    CagrRankingItem {
+        rank: item.rank,
+        stock_symbol: item.cagr.stock_symbol,
+        name: item.name,
+        stock_industry_id: item.industry_id,
+        base_date: item.cagr.base_date.map(|value| value.to_string()),
+        first_quote_date: item.cagr.first_quote_date.map(|value| value.to_string()),
+        shortfall_days: item.cagr.shortfall_days,
+        base_price: decimal_ratio(item.cagr.base_price),
+        end_price: decimal_ratio(item.cagr.end_price),
+        end_shares: decimal_shares(outcome.map(|value| value.end_shares)),
+        cash_received: decimal_ratio(outcome.map(|value| value.cash_received)),
+        end_value: decimal_ratio(outcome.map(|value| value.end_value)),
+        total_return_pct: decimal_ratio(outcome.map(|value| value.total_return_pct)),
+        cagr_pct: decimal_ratio(outcome.map(|value| value.cagr_pct)),
+        dividend_events: item.cagr.dividend_events,
+        data_complete: item.cagr.data_complete,
+        has_anomaly: item.cagr.has_anomaly,
+    }
+}
+
+/// 將個股單一期間的領域實體轉成 API DTO。
+fn cagr_period_item(
+    record: DomainStockCagr,
+    name: &str,
+    industry_id: i32,
+    metric: CagrMetric,
+) -> CagrPeriodItem {
+    let outcome = cagr_outcome(&record, metric);
+    CagrPeriodItem {
+        period: record.period.code().to_owned(),
+        stock_symbol: record.stock_symbol,
+        name: name.to_owned(),
+        stock_industry_id: industry_id,
+        base_date: record.base_date.map(|value| value.to_string()),
+        first_quote_date: record.first_quote_date.map(|value| value.to_string()),
+        shortfall_days: record.shortfall_days,
+        base_price: decimal_ratio(record.base_price),
+        end_price: decimal_ratio(record.end_price),
+        end_shares: decimal_shares(outcome.map(|value| value.end_shares)),
+        cash_received: decimal_ratio(outcome.map(|value| value.cash_received)),
+        end_value: decimal_ratio(outcome.map(|value| value.end_value)),
+        total_return_pct: decimal_ratio(outcome.map(|value| value.total_return_pct)),
+        cagr_pct: decimal_ratio(outcome.map(|value| value.cagr_pct)),
+        years: decimal_ratio(record.years),
+        dividend_events: record.dividend_events,
+        data_complete: record.data_complete,
+        has_anomaly: record.has_anomaly,
+        survivorship_note: record.period.requires_coverage_disclosure(),
+    }
+}
+
+/// 取本頁可算項目中最常見的期初交易日。
+///
+/// 同票數時取較晚的日期，讓結果與資料列順序無關（可重現）。
+fn representative_base_date(items: &[DomainCagrRankingItem]) -> Option<NaiveDate> {
+    let mut counts: std::collections::HashMap<NaiveDate, usize> = std::collections::HashMap::new();
+    for item in items.iter().filter(|item| item.cagr.data_complete) {
+        if let Some(value) = item.cagr.base_date {
+            *counts.entry(value).or_default() += 1;
+        }
+    }
+    counts
+        .into_iter()
+        .max_by_key(|(date, count)| (*count, *date))
+        .map(|(date, _)| date)
+}
+
+/// 記錄倉儲層錯誤並回傳安全的 500 訊息。
+///
+/// 與 [`database_error`] 分開是因為倉儲回傳的是 `anyhow::Error`（帶 context
+/// 鏈），對外仍只給固定訊息，不洩漏 SQL 或連線資訊。
+fn repository_error(error: anyhow::Error) -> Response {
+    tracing::error!(?error, "data API repository query failed");
+    error_response(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "伺服器內部發生未預期錯誤",
+    )
+}
+
 #[cfg(test)]
 mod tests {
     //! 純函式轉換邏輯的 deterministic tests（計畫 §9 Phase 1 要求）。
@@ -2501,5 +2871,292 @@ mod tests {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod cagr_tests {
+    //! 每日 CAGR endpoint 的純函式測試（M4）。
+    //!
+    //! 全部不需要資料庫：參數解析、白名單驗證與 Decimal → 字串序列化都是
+    //! 純運算，而這三者正是前端契約最容易在重構時被悄悄改掉的部分。
+
+    use chrono::NaiveDate;
+    use rust_decimal_macros::dec;
+
+    use super::{
+        DomainCagrRankingItem, DomainStockCagr, cagr_market_id, cagr_period_item,
+        cagr_ranking_item, decimal_ratio, decimal_shares, normalize_cagr_keyword,
+        parse_cagr_metric, parse_cagr_period, representative_base_date,
+    };
+    use crate::domain::performance::entity::{CagrMetric, CagrPeriod, SimulationOutcome};
+    use crate::domain::performance::query::CagrSortKey;
+
+    /// 建立一筆資料齊全的領域結果。
+    fn complete(symbol: &str, period: CagrPeriod, base_date: NaiveDate) -> DomainStockCagr {
+        DomainStockCagr {
+            date: NaiveDate::from_ymd_opt(2026, 8, 6).unwrap(),
+            stock_symbol: symbol.to_owned(),
+            period,
+            base_date: Some(base_date),
+            base_price: Some(dec!(178)),
+            end_price: Some(dec!(1340)),
+            years: Some(dec!(10.002740)),
+            price: None,
+            total: Some(SimulationOutcome {
+                end_shares: dec!(56.17977528),
+                cash_received: dec!(6797.7528),
+                end_value: dec!(82078.6517),
+                total_return_pct: dec!(720.7865),
+                cagr_pct: dec!(23.4318),
+            }),
+            reinvested: None,
+            first_quote_date: NaiveDate::from_ymd_opt(2015, 3, 2),
+            shortfall_days: Some(0),
+            data_complete: true,
+            has_anomaly: false,
+            dividend_events: 38,
+        }
+    }
+
+    /// 建立一筆資料不足的領域結果（所有數值欄位皆為 None）。
+    fn incomplete(symbol: &str, period: CagrPeriod) -> DomainStockCagr {
+        DomainStockCagr {
+            date: NaiveDate::from_ymd_opt(2026, 8, 6).unwrap(),
+            stock_symbol: symbol.to_owned(),
+            period,
+            base_date: None,
+            base_price: None,
+            end_price: None,
+            years: None,
+            price: None,
+            total: None,
+            reinvested: None,
+            first_quote_date: NaiveDate::from_ymd_opt(2024, 5, 1),
+            shortfall_days: None,
+            data_complete: false,
+            has_anomaly: false,
+            dividend_events: 0,
+        }
+    }
+
+    /// 建立排行榜項目。
+    fn ranking_item(cagr: DomainStockCagr, rank: Option<i64>) -> DomainCagrRankingItem {
+        DomainCagrRankingItem {
+            cagr,
+            name: "台積電".to_owned(),
+            industry_id: 24,
+            rank,
+        }
+    }
+
+    /// 十年期範例使用的期初交易日。
+    fn base_date() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2016, 8, 5).unwrap()
+    }
+
+    /// `period` 與 `metric` 的預設值與白名單必須與前端契約一致。
+    #[test]
+    fn test_period_and_metric_defaults_and_whitelist() {
+        assert_eq!(parse_cagr_period(None), Ok(CagrPeriod::Y1));
+        assert_eq!(parse_cagr_metric(None), Ok(CagrMetric::Total));
+        for period in CagrPeriod::ALL {
+            assert_eq!(parse_cagr_period(Some(period.code())), Ok(period));
+        }
+        for metric in CagrMetric::ALL {
+            assert_eq!(parse_cagr_metric(Some(metric.code())), Ok(metric));
+        }
+        // 大小寫與別名一律不接受，避免前後端對「y1」是否合法各自解讀。
+        assert!(parse_cagr_period(Some("y1")).is_err());
+        assert!(parse_cagr_period(Some("Y7")).is_err());
+        assert!(parse_cagr_metric(Some("TOTAL")).is_err());
+        assert!(parse_cagr_metric(Some("cash")).is_err());
+    }
+
+    /// 未指定 `sort` 時，短期間必須改用區間總報酬——年化會被放大約四倍。
+    #[test]
+    fn test_default_sort_key_follows_period_length() {
+        assert_eq!(
+            CagrSortKey::default_for(CagrPeriod::M3),
+            CagrSortKey::TotalReturn
+        );
+        assert_eq!(
+            CagrSortKey::default_for(CagrPeriod::M6),
+            CagrSortKey::TotalReturn
+        );
+        for period in [CagrPeriod::Y1, CagrPeriod::Y5, CagrPeriod::Y10] {
+            assert_eq!(CagrSortKey::default_for(period), CagrSortKey::Cagr);
+        }
+        assert_eq!(
+            CagrSortKey::from_code("total_return"),
+            Some(CagrSortKey::TotalReturn)
+        );
+        assert_eq!(CagrSortKey::from_code("cagr"), Some(CagrSortKey::Cagr));
+        assert_eq!(CagrSortKey::from_code("CAGR"), None);
+    }
+
+    /// 長期間不得提供純價格口徑；判準取自領域層而非在 handler 硬寫。
+    #[test]
+    fn test_long_periods_reject_price_metric() {
+        for period in [CagrPeriod::Y5, CagrPeriod::Y10] {
+            assert!(!period.supports_price_metric(), "{period:?} 應拒絕純價格");
+            assert!(period.requires_coverage_disclosure());
+        }
+        for period in [CagrPeriod::M3, CagrPeriod::Y1, CagrPeriod::Y3] {
+            assert!(period.supports_price_metric());
+            assert!(!period.requires_coverage_disclosure());
+        }
+    }
+
+    /// `market` 白名單：`all` 代表不篩選，其餘映射到市場編號。
+    #[test]
+    fn test_market_parameter_whitelist() {
+        assert_eq!(cagr_market_id("all"), Ok(None));
+        assert_eq!(cagr_market_id("twse"), Ok(Some(2)));
+        assert_eq!(cagr_market_id("tpex"), Ok(Some(4)));
+        assert_eq!(cagr_market_id("5"), Ok(Some(5)));
+        assert!(cagr_market_id("0").is_err());
+        assert!(cagr_market_id("-1").is_err());
+        assert!(cagr_market_id("emerging").is_err());
+    }
+
+    /// 關鍵字去空白後為空即視為未指定，過長則拒絕。
+    #[test]
+    fn test_keyword_normalization() {
+        assert_eq!(normalize_cagr_keyword(None), Ok(None));
+        assert_eq!(normalize_cagr_keyword(Some("   ")), Ok(None));
+        assert_eq!(
+            normalize_cagr_keyword(Some("  台積  ")),
+            Ok(Some("台積".to_owned()))
+        );
+        assert!(normalize_cagr_keyword(Some(&"台".repeat(51))).is_err());
+    }
+
+    /// 金額與股數必須是固定小數位的字串——JSON number 會經過 f64 掉精度。
+    #[test]
+    fn test_decimal_serializes_as_fixed_scale_string() {
+        assert_eq!(decimal_ratio(Some(dec!(178))), Some("178.0000".to_owned()));
+        assert_eq!(
+            decimal_ratio(Some(dec!(82078.6517))),
+            Some("82078.6517".to_owned())
+        );
+        assert_eq!(
+            decimal_ratio(Some(dec!(10.002740))),
+            Some("10.0027".to_owned())
+        );
+        assert_eq!(
+            decimal_shares(Some(dec!(56.17977528))),
+            Some("56.17977528".to_owned())
+        );
+        assert_eq!(decimal_ratio(None), None);
+        assert_eq!(decimal_shares(None), None);
+    }
+
+    /// 可算項目的每個欄位都要對到正確來源，且名次原樣帶出。
+    #[test]
+    fn test_ranking_item_maps_selected_metric() {
+        let item = ranking_item(complete("2330", CagrPeriod::Y10, base_date()), Some(1));
+        let dto = cagr_ranking_item(item, CagrMetric::Total);
+        assert_eq!(dto.rank, Some(1));
+        assert_eq!(dto.stock_symbol, "2330");
+        assert_eq!(dto.name, "台積電");
+        assert_eq!(dto.stock_industry_id, 24);
+        assert_eq!(dto.base_date.as_deref(), Some("2016-08-05"));
+        assert_eq!(dto.first_quote_date.as_deref(), Some("2015-03-02"));
+        assert_eq!(dto.shortfall_days, Some(0));
+        assert_eq!(dto.base_price.as_deref(), Some("178.0000"));
+        assert_eq!(dto.end_price.as_deref(), Some("1340.0000"));
+        assert_eq!(dto.end_shares.as_deref(), Some("56.17977528"));
+        assert_eq!(dto.cash_received.as_deref(), Some("6797.7528"));
+        assert_eq!(dto.end_value.as_deref(), Some("82078.6517"));
+        assert_eq!(dto.total_return_pct.as_deref(), Some("720.7865"));
+        assert_eq!(dto.cagr_pct.as_deref(), Some("23.4318"));
+        assert_eq!(dto.dividend_events, 38);
+        assert!(dto.data_complete);
+        assert!(!dto.has_anomaly);
+    }
+
+    /// 未計算的口徑（此處為純價格）必須是 null，不可退回主指標的數字。
+    #[test]
+    fn test_ranking_item_missing_metric_is_null() {
+        let item = ranking_item(complete("2330", CagrPeriod::Y10, base_date()), Some(1));
+        let dto = cagr_ranking_item(item, CagrMetric::Price);
+        assert!(dto.end_shares.is_none());
+        assert!(dto.cash_received.is_none());
+        assert!(dto.end_value.is_none());
+        assert!(dto.total_return_pct.is_none());
+        assert!(dto.cagr_pct.is_none());
+        // 期初／期末價屬於該列本身，與口徑無關，仍應有值。
+        assert!(dto.base_price.is_some());
+    }
+
+    /// 資料不足的項目要留在清單裡並回 null，而不是被省略。
+    #[test]
+    fn test_incomplete_item_keeps_row_with_null_fields() {
+        let mut item = ranking_item(incomplete("6666", CagrPeriod::Y10), None);
+        item.name = "測試股".to_owned();
+        item.industry_id = 3;
+        let dto = cagr_ranking_item(item, CagrMetric::Total);
+        assert_eq!(dto.rank, None, "資料不足不得佔名次");
+        assert_eq!(dto.stock_symbol, "6666");
+        assert!(!dto.data_complete);
+        for field in [
+            &dto.base_date,
+            &dto.base_price,
+            &dto.end_price,
+            &dto.end_shares,
+            &dto.cash_received,
+            &dto.end_value,
+            &dto.total_return_pct,
+            &dto.cagr_pct,
+        ] {
+            assert!(field.is_none(), "資料不足時所有數值欄位必須是 null");
+        }
+        assert!(dto.shortfall_days.is_none());
+        // 查得到但算不出來：仍保留最早報價日，供前端說明為何算不出來。
+        assert_eq!(dto.first_quote_date.as_deref(), Some("2024-05-01"));
+    }
+
+    /// 個股項目多一個 period、帶 years 與該期間的揭露旗標。
+    #[test]
+    fn test_period_item_carries_period_and_disclosure_flag() {
+        let dto = cagr_period_item(
+            complete("2330", CagrPeriod::Y10, base_date()),
+            "台積電",
+            24,
+            CagrMetric::Total,
+        );
+        assert_eq!(dto.period, "Y10");
+        assert_eq!(dto.years.as_deref(), Some("10.0027"));
+        assert_eq!(dto.stock_industry_id, 24);
+        assert!(dto.survivorship_note);
+
+        let short = cagr_period_item(
+            complete("2330", CagrPeriod::M3, base_date()),
+            "台積電",
+            24,
+            CagrMetric::Total,
+        );
+        assert_eq!(short.period, "M3");
+        assert!(!short.survivorship_note);
+    }
+
+    /// 表頭期初日取可算項目中最常見者，且不受資料不足項目干擾。
+    #[test]
+    fn test_representative_base_date_ignores_incomplete_rows() {
+        let common = base_date();
+        let delayed = NaiveDate::from_ymd_opt(2016, 8, 22).unwrap();
+        let items = vec![
+            ranking_item(complete("a", CagrPeriod::Y10, common), Some(1)),
+            ranking_item(complete("b", CagrPeriod::Y10, delayed), Some(2)),
+            ranking_item(complete("c", CagrPeriod::Y10, common), Some(3)),
+            ranking_item(incomplete("d", CagrPeriod::Y10), None),
+        ];
+        assert_eq!(representative_base_date(&items), Some(common));
+        assert_eq!(representative_base_date(&[]), None);
+        assert_eq!(
+            representative_base_date(&[ranking_item(incomplete("d", CagrPeriod::Y10), None)]),
+            None
+        );
     }
 }

--- a/src/interfaces/web/data_api/handlers.rs
+++ b/src/interfaces/web/data_api/handlers.rs
@@ -2330,7 +2330,7 @@ pub(super) async fn cagr_by_symbol(
 /// 解析 `period` 查詢參數；未提供時預設 `Y1`。
 fn parse_cagr_period(value: Option<&str>) -> Result<CagrPeriod, &'static str> {
     CagrPeriod::from_code(value.unwrap_or("Y1"))
-        .ok_or("period 必須為 M3、M6、Y1、Y1H、Y2、Y3、Y5 或 Y10")
+        .ok_or("period 必須為 M3、M6、Y1、Y1H、Y2、Y3、Y5、Y7 或 Y10")
 }
 
 /// 解析 `metric` 查詢參數；未提供時預設主指標 `total`。
@@ -2968,7 +2968,7 @@ mod cagr_tests {
         }
         // 大小寫與別名一律不接受，避免前後端對「y1」是否合法各自解讀。
         assert!(parse_cagr_period(Some("y1")).is_err());
-        assert!(parse_cagr_period(Some("Y7")).is_err());
+        assert!(parse_cagr_period(Some("Y8")).is_err());
         assert!(parse_cagr_metric(Some("TOTAL")).is_err());
         assert!(parse_cagr_metric(Some("cash")).is_err());
     }

--- a/src/interfaces/web/data_api/mod.rs
+++ b/src/interfaces/web/data_api/mod.rs
@@ -1377,7 +1377,9 @@ mod tests {
     ///
     /// 代號一律以 `79979` 開頭（真實市場不存在），基準日固定 1990-01-02，
     /// 遠早於本功能上線，不會與正式資料互相干擾。
-    #[cfg(feature = "integration-tests")]
+    ///
+    /// 不加 `#[cfg(feature = "integration-tests")]`：使用它的測試函式在未開
+    /// feature 時只是被標記為 `ignore`，本體仍要通過編譯。
     mod cagr_seed {
         use chrono::NaiveDate;
         use rust_decimal_macros::dec;

--- a/src/interfaces/web/data_api/mod.rs
+++ b/src/interfaces/web/data_api/mod.rs
@@ -14,8 +14,8 @@ use utoipa_swagger_ui::SwaggerUi;
 /// 由 handler 註解生成的 OpenAPI 3 文件。
 #[derive(OpenApi)]
 #[openapi(
-    paths(handlers::search_stocks, handlers::latest_quote, handlers::price_history, handlers::stock_profile, handlers::realtime_snapshot, handlers::monthly_revenues, handlers::financial_statements, handlers::dividend_history, handlers::stock_valuation, handlers::market_breadth, handlers::dividend_yield_ranking, handlers::screen_stocks, handlers::market_index_history, handlers::dividend_calendar, handlers::qfii_holding_ranking, handlers::healthz),
-    components(schemas(dto::Stock, dto::DailyQuote, dto::HistoricalQuote, dto::QuoteHistoryRecord, dto::StockProfile, dto::SearchResponse, dto::LatestQuoteResponse, dto::PriceHistoryResponse, dto::RealtimeSnapshotResponse, dto::MonthlyRevenue, dto::MonthlyRevenueResponse, dto::FinancialStatement, dto::FinancialStatementHistoryResponse, dto::Dividend, dto::DividendHistoryResponse, dto::StockValuation, dto::StockValuationResponse, dto::MarketBreadth, dto::MarketBreadthResponse, dto::DividendYieldRank, dto::DividendYieldRankingResponse, dto::ScreenedStock, dto::StockScreeningResponse, dto::MarketIndexPoint, dto::MarketIndexHistoryResponse, dto::DividendCalendarEvent, dto::DividendCalendarResponse, dto::QfiiHolding, dto::QfiiHoldingRankingResponse, dto::ErrorBody, dto::HealthResponse)),
+    paths(handlers::search_stocks, handlers::latest_quote, handlers::price_history, handlers::stock_profile, handlers::realtime_snapshot, handlers::monthly_revenues, handlers::financial_statements, handlers::dividend_history, handlers::stock_valuation, handlers::market_breadth, handlers::dividend_yield_ranking, handlers::screen_stocks, handlers::market_index_history, handlers::dividend_calendar, handlers::qfii_holding_ranking, handlers::cagr_ranking, handlers::cagr_by_symbol, handlers::healthz),
+    components(schemas(dto::Stock, dto::DailyQuote, dto::HistoricalQuote, dto::QuoteHistoryRecord, dto::StockProfile, dto::SearchResponse, dto::LatestQuoteResponse, dto::PriceHistoryResponse, dto::RealtimeSnapshotResponse, dto::MonthlyRevenue, dto::MonthlyRevenueResponse, dto::FinancialStatement, dto::FinancialStatementHistoryResponse, dto::Dividend, dto::DividendHistoryResponse, dto::StockValuation, dto::StockValuationResponse, dto::MarketBreadth, dto::MarketBreadthResponse, dto::DividendYieldRank, dto::DividendYieldRankingResponse, dto::ScreenedStock, dto::StockScreeningResponse, dto::MarketIndexPoint, dto::MarketIndexHistoryResponse, dto::DividendCalendarEvent, dto::DividendCalendarResponse, dto::QfiiHolding, dto::QfiiHoldingRankingResponse, dto::CagrCoverageInfo, dto::CagrSummary, dto::CagrRankingItem, dto::CagrRankingResponse, dto::CagrPeriodItem, dto::CagrSymbolResponse, dto::ErrorBody, dto::HealthResponse)),
     tags((name = "data-api", description = "唯讀股票資料查詢")),
     security(("bearer_auth" = [])),
     modifiers(&SecurityAddon)
@@ -103,6 +103,14 @@ pub(super) fn router() -> Router {
         .route(
             "/market/qfii-holding-ranking",
             axum::routing::get(handlers::qfii_holding_ranking),
+        )
+        .route(
+            "/market/cagr-ranking",
+            axum::routing::get(handlers::cagr_ranking),
+        )
+        .route(
+            "/market/cagr-ranking/{stock_symbol}",
+            axum::routing::get(handlers::cagr_by_symbol),
         )
         .layer(middleware::from_fn(auth::require_bearer_key));
     Router::new()
@@ -260,6 +268,8 @@ mod tests {
             "/api/v1/market/index-history",
             "/api/v1/market/dividend-calendar",
             "/api/v1/market/qfii-holding-ranking",
+            "/api/v1/market/cagr-ranking",
+            "/api/v1/market/cagr-ranking/{stock_symbol}",
             "/api/v1/healthz",
         ] {
             assert!(json.contains(path), "OpenAPI should contain {path}");
@@ -934,6 +944,357 @@ mod tests {
                 response.status(),
                 StatusCode::UNAUTHORIZED,
                 "{path} 應回 401"
+            );
+        }
+    }
+
+    /// M4 每日 CAGR 兩條 path 的 OpenAPI 契約：responses、白名單 enum、
+    /// 預設值與陣列 item；並釘住「所有金額與比率為字串」這條前端契約。
+    #[test]
+    fn openapi_cagr_schemas_pin_field_names() {
+        let document = serde_json::to_value(ApiDoc::openapi()).expect("OpenAPI 可序列化");
+
+        let ranking = get_operation(&document, "/api/v1/market/cagr-ranking");
+        assert_endpoint_responses(ranking, "CagrRankingResponse", true);
+        let period = query_schema(ranking, "period");
+        assert_eq!(period["default"], "Y1");
+        assert_eq!(
+            enum_values(&document, period),
+            serde_json::json!(["M3", "M6", "Y1", "Y1H", "Y2", "Y3", "Y5", "Y10"])
+        );
+        let metric = query_schema(ranking, "metric");
+        assert_eq!(metric["default"], "total");
+        assert_eq!(
+            enum_values(&document, metric),
+            serde_json::json!(["price", "total", "reinvested"])
+        );
+        assert_eq!(
+            enum_values(&document, query_schema(ranking, "sort")),
+            serde_json::json!(["cagr", "total_return"])
+        );
+        assert_eq!(query_schema(ranking, "market")["default"], "all");
+        assert_eq!(query_schema(ranking, "stock_industry_id")["minimum"], 1);
+        assert_eq!(query_schema(ranking, "include_incomplete")["default"], true);
+        let limit = query_schema(ranking, "limit");
+        assert_eq!(limit["default"], 50);
+        assert_eq!(limit["minimum"], 1);
+        assert_eq!(limit["maximum"], 200);
+        let offset = query_schema(ranking, "offset");
+        assert_eq!(offset["default"], 0);
+        assert_eq!(offset["minimum"], 0);
+
+        let properties = &document["components"]["schemas"]["CagrRankingResponse"]["properties"];
+        assert_eq!(properties["items"]["type"], "array");
+        assert_eq!(
+            properties["items"]["items"]["$ref"],
+            "#/components/schemas/CagrRankingItem"
+        );
+        // principal 與各種計數是整數，維持 JSON number。
+        assert_eq!(properties["principal"]["type"], "integer");
+        assert_eq!(properties["total"]["type"], "integer");
+        // base_date／years 在整頁皆資料不足時為 null。
+        assert!(properties["base_date"].to_string().contains("null"));
+        assert!(properties["years"].to_string().contains("null"));
+
+        // §M4 契約核心：Decimal 一律字串，計數一律整數。
+        let coverage = &document["components"]["schemas"]["CagrCoverageInfo"]["properties"];
+        assert_eq!(coverage["coverage_ratio"]["type"], "string");
+        assert_eq!(coverage["universe"]["type"], "integer");
+        assert_eq!(coverage["counted"]["type"], "integer");
+        assert_eq!(coverage["survivorship_note"]["type"], "boolean");
+        let summary = &document["components"]["schemas"]["CagrSummary"]["properties"];
+        assert_eq!(summary["positive"]["type"], "integer");
+        assert_eq!(summary["positive_ratio"]["type"], "string");
+
+        let item = &document["components"]["schemas"]["CagrRankingItem"]["properties"];
+        for field in [
+            "base_price",
+            "end_price",
+            "end_shares",
+            "cash_received",
+            "end_value",
+            "total_return_pct",
+            "cagr_pct",
+        ] {
+            let schema = item[field].to_string();
+            assert!(schema.contains("string"), "{field} 必須序列化為字串");
+            assert!(schema.contains("null"), "{field} 資料不足時必須可為 null");
+        }
+        assert!(item["rank"].to_string().contains("null"));
+        assert_eq!(item["dividend_events"]["type"], "integer");
+        assert_eq!(item["data_complete"]["type"], "boolean");
+        assert_eq!(item["stock_industry_id"]["type"], "integer");
+
+        // 個股端點：items 是 CagrPeriodItem（多 period、無 rank）。
+        let symbol = get_operation(&document, "/api/v1/market/cagr-ranking/{stock_symbol}");
+        assert_endpoint_responses(symbol, "CagrSymbolResponse", true);
+        assert_eq!(query_schema(symbol, "metric")["default"], "total");
+        let symbol_properties =
+            &document["components"]["schemas"]["CagrSymbolResponse"]["properties"];
+        assert_eq!(symbol_properties["items"]["type"], "array");
+        assert_eq!(
+            symbol_properties["items"]["items"]["$ref"],
+            "#/components/schemas/CagrPeriodItem"
+        );
+        let period_item = &document["components"]["schemas"]["CagrPeriodItem"]["properties"];
+        assert_eq!(period_item["period"]["type"], "string");
+        assert!(period_item["years"].to_string().contains("string"));
+        assert!(
+            period_item.get("rank").is_none(),
+            "個股端點的項目不應有 rank"
+        );
+    }
+
+    /// M4 兩個 endpoint 都必須在 middleware 層拒絕未授權請求。
+    #[tokio::test]
+    async fn cagr_endpoints_reject_missing_bearer_key() {
+        for path in [
+            "/api/v1/market/cagr-ranking",
+            "/api/v1/market/cagr-ranking/2330",
+        ] {
+            let response = router()
+                .oneshot(
+                    Request::get(path)
+                        .body(Body::empty())
+                        .expect("request should build"),
+                )
+                .await
+                .expect("router should serve request");
+            assert_eq!(
+                response.status(),
+                StatusCode::UNAUTHORIZED,
+                "{path} 應回 401"
+            );
+        }
+    }
+
+    /// M4 參數驗證一律在觸及資料庫之前完成，因此此測試不需要 PostgreSQL。
+    ///
+    /// 最關鍵的是 `Y5`／`Y10` 搭配 `metric=price` 必須回 422：近十年每年皆有
+    /// 134–216 檔股票配股，長期間忽略配股的低估幅度顯著，不能默默回答。
+    #[tokio::test]
+    async fn cagr_ranking_rejects_invalid_parameters_before_any_query() {
+        // Auth middleware 讀環境變數 DATA_API_KEY；測試環境沒設定時自行
+        // 補一組（CI 以 --test-threads=1 執行，無資料競爭疑慮）。
+        let key = std::env::var("DATA_API_KEY").unwrap_or_else(|_| {
+            let generated = "cagr-param-test-key".to_owned();
+            unsafe { std::env::set_var("DATA_API_KEY", &generated) };
+            generated
+        });
+        for path in [
+            // 期間、口徑、排序鍵的白名單。
+            "/api/v1/market/cagr-ranking?period=Y7",
+            "/api/v1/market/cagr-ranking?period=y1",
+            "/api/v1/market/cagr-ranking?metric=cash",
+            "/api/v1/market/cagr-ranking?sort=return",
+            // 長期間不提供純價格口徑。
+            "/api/v1/market/cagr-ranking?period=Y5&metric=price",
+            "/api/v1/market/cagr-ranking?period=Y10&metric=price",
+            // 市場、產業、關鍵字、分頁與日期。
+            "/api/v1/market/cagr-ranking?market=emerging",
+            "/api/v1/market/cagr-ranking?stock_industry_id=0",
+            "/api/v1/market/cagr-ranking?limit=0",
+            "/api/v1/market/cagr-ranking?limit=201",
+            "/api/v1/market/cagr-ranking?date=2026-8-6",
+            // 個股端點共用同一組解析器。
+            "/api/v1/market/cagr-ranking/2330?metric=cash",
+            "/api/v1/market/cagr-ranking/2330?date=2026-08-6",
+        ] {
+            let response = router()
+                .oneshot(
+                    Request::get(path)
+                        .header("Authorization", format!("Bearer {key}"))
+                        .body(Body::empty())
+                        .expect("request should build"),
+                )
+                .await
+                .expect("router should serve request");
+            assert_eq!(
+                response.status(),
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "{path} 應回 422"
+            );
+        }
+        // 短期間可用純價格口徑這條正向路徑會觸及資料庫，交由整合測試
+        // （cagr_endpoints_db_semantics）驗證，此處刻意不發出該請求。
+    }
+
+    /// M4 兩個 endpoint 的真實資料庫語意整合測試（唯讀，不建立任何 fixture）。
+    ///
+    /// 驗證：全市場名次不受篩選影響且遞增、資料不足項目 `rank` 為 null 且
+    /// 排在最後、金額欄位序列化為字串、涵蓋率分母正確，以及個股端點回傳
+    /// 全部八個期間並依期間長度排序。M3 排程尚未產出資料時安全跳過。
+    #[tokio::test]
+    #[cfg_attr(
+        not(feature = "integration-tests"),
+        ignore = "需要外部服務（PostgreSQL），請加 --features integration-tests 執行"
+    )]
+    async fn cagr_endpoints_db_semantics() {
+        dotenvy::dotenv().ok();
+        if sqlx::query("SELECT 1")
+            .execute(crate::infra::database::get_connection())
+            .await
+            .is_err()
+        {
+            println!("跳過 cagr_endpoints_db_semantics：無資料庫連接");
+            return;
+        }
+        let key = std::env::var("DATA_API_KEY").unwrap_or_else(|_| {
+            let generated = "cagr-integration-test-key".to_owned();
+            unsafe { std::env::set_var("DATA_API_KEY", &generated) };
+            generated
+        });
+        let get = |path: String| {
+            let key = key.clone();
+            async move {
+                let response = router()
+                    .oneshot(
+                        Request::get(&path)
+                            .header("Authorization", format!("Bearer {key}"))
+                            .body(Body::empty())
+                            .expect("request should build"),
+                    )
+                    .await
+                    .expect("router should serve request");
+                let status = response.status();
+                let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .expect("body should be readable");
+                let json: serde_json::Value =
+                    serde_json::from_slice(&bytes).expect("body should be JSON");
+                (status, json)
+            }
+        };
+
+        // 先以「必然無資料的基準日」跑一次完整查詢：即使排程尚未產出任何
+        // 結果，這條路徑仍會把排行 SQL（CTE、視窗函式、三個篩選、分頁）
+        // 送進 PostgreSQL，語法或欄位錯誤會立刻現形。
+        for path in [
+            "/api/v1/market/cagr-ranking?date=1990-01-02&period=Y1",
+            "/api/v1/market/cagr-ranking?date=1990-01-02&period=M3&sort=total_return",
+            "/api/v1/market/cagr-ranking?date=1990-01-02&period=Y3&metric=price&market=twse",
+            "/api/v1/market/cagr-ranking?date=1990-01-02&metric=reinvested&stock_industry_id=24",
+            "/api/v1/market/cagr-ranking?date=1990-01-02&keyword=%E5%8F%B0%E7%A9%8D&offset=10",
+            "/api/v1/market/cagr-ranking?date=1990-01-02&include_incomplete=false&limit=200",
+        ] {
+            let (status, json) = get(path.to_owned()).await;
+            assert_eq!(status, StatusCode::OK, "{path} 應能在真實 schema 執行");
+            assert_eq!(json["items"], serde_json::json!([]));
+            assert_eq!(json["total"], 0);
+            assert_eq!(json["coverage"]["universe"], 0);
+            assert_eq!(json["base_date"], serde_json::Value::Null);
+            assert_eq!(json["coverage"]["coverage_ratio"], "0.0000");
+            assert_eq!(json["summary"]["positive_ratio"], "0.0000");
+        }
+
+        let (status, json) = get("/api/v1/market/cagr-ranking?period=Y1&limit=50".to_owned()).await;
+        if status == StatusCode::NOT_FOUND {
+            println!("跳過 cagr_endpoints_db_semantics：stock_cagr 尚無計算結果");
+            return;
+        }
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["period"], "Y1");
+        assert_eq!(json["metric"], "total");
+        assert_eq!(json["sort"], "cagr", "Y1 預設應以年化報酬率排序");
+        assert_eq!(json["principal"], 10_000);
+        assert_eq!(json["coverage"]["survivorship_note"], false);
+        // 比率一律是字串（四位小數），不可是 JSON number。
+        for pointer in ["/coverage/coverage_ratio", "/summary/positive_ratio"] {
+            let value = json.pointer(pointer).expect("ratio 欄位應存在");
+            assert!(value.is_string(), "{pointer} 必須序列化為字串");
+        }
+
+        let items = json["items"].as_array().expect("items array");
+        let mut previous_rank = 0_i64;
+        let mut seen_incomplete = false;
+        for item in items {
+            match item["rank"].as_i64() {
+                Some(rank) => {
+                    assert!(!seen_incomplete, "資料不足的項目必須排在所有可算項目之後");
+                    assert!(rank > previous_rank, "名次必須嚴格遞增");
+                    assert!(item["data_complete"].as_bool().unwrap_or(false));
+                    assert!(item["cagr_pct"].is_string(), "金額與比率必須是字串");
+                    assert!(item["end_shares"].is_string());
+                    previous_rank = rank;
+                }
+                None => {
+                    seen_incomplete = true;
+                    // 查得到但算不出來：列仍在，數值欄位為 null。
+                    assert!(item["cagr_pct"].is_null());
+                    assert!(item["end_value"].is_null());
+                    assert!(item["stock_symbol"].is_string());
+                }
+            }
+        }
+
+        // 全市場名次：套用產業篩選後，名次仍是未篩選的完整市場排名，
+        // 因此第一筆的 rank 只會 >= 未篩選時的第一筆。
+        if let Some(industry) = items
+            .iter()
+            .find(|item| item["rank"].as_i64() == Some(1))
+            .and_then(|item| item["stock_industry_id"].as_i64())
+        {
+            let (status, filtered) = get(format!(
+                "/api/v1/market/cagr-ranking?period=Y1&stock_industry_id={industry}&limit=50"
+            ))
+            .await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(
+                filtered["coverage"], json["coverage"],
+                "涵蓋統計不隨畫面篩選變動"
+            );
+            assert!(
+                filtered["total"].as_i64() <= json["total"].as_i64(),
+                "篩選後的 total 不可大於未篩選"
+            );
+            if let Some(first) = filtered["items"]
+                .as_array()
+                .and_then(|list| list.first())
+                .and_then(|item| item["rank"].as_i64())
+            {
+                assert!(first >= 1, "篩選後的名次仍是全市場名次");
+            }
+        }
+
+        // Y10 + price 由 handler 在任何 SQL 之前擋下。
+        let (status, _) =
+            get("/api/v1/market/cagr-ranking?period=Y10&metric=price".to_owned()).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+
+        // Y10 的揭露旗標必須為 true。
+        let (status, json) = get("/api/v1/market/cagr-ranking?period=Y10&limit=1".to_owned()).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["coverage"]["survivorship_note"], true);
+
+        // 個股端點：未知代號 404；已知代號回傳全部八個期間且由短至長。
+        let (status, _) = get("/api/v1/market/cagr-ranking/NO_SUCH_SYMBOL".to_owned()).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        if let Some(symbol) = items
+            .first()
+            .and_then(|item| item["stock_symbol"].as_str())
+            .map(str::to_owned)
+        {
+            let (status, json) = get(format!("/api/v1/market/cagr-ranking/{symbol}")).await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(json["stock_symbol"], symbol);
+            let periods: Vec<&str> = json["items"]
+                .as_array()
+                .expect("items array")
+                .iter()
+                .map(|item| item["period"].as_str().expect("period string"))
+                .collect();
+            assert_eq!(
+                periods,
+                vec!["M3", "M6", "Y1", "Y1H", "Y2", "Y3", "Y5", "Y10"],
+                "個股端點必須回傳全部八個期間且依期間長度排序"
+            );
+            assert!(
+                json["items"]
+                    .as_array()
+                    .expect("items array")
+                    .iter()
+                    .all(|item| item["rank"].is_null()),
+                "個股端點的項目不應有名次"
             );
         }
     }

--- a/src/interfaces/web/data_api/mod.rs
+++ b/src/interfaces/web/data_api/mod.rs
@@ -960,7 +960,7 @@ mod tests {
         assert_eq!(period["default"], "Y1");
         assert_eq!(
             enum_values(&document, period),
-            serde_json::json!(["M3", "M6", "Y1", "Y1H", "Y2", "Y3", "Y5", "Y10"])
+            serde_json::json!(["M3", "M6", "Y1", "Y1H", "Y2", "Y3", "Y5", "Y7", "Y10"])
         );
         let metric = query_schema(ranking, "metric");
         assert_eq!(metric["default"], "total");
@@ -1083,7 +1083,7 @@ mod tests {
         });
         for path in [
             // 期間、口徑、排序鍵的白名單。
-            "/api/v1/market/cagr-ranking?period=Y7",
+            "/api/v1/market/cagr-ranking?period=Y8",
             "/api/v1/market/cagr-ranking?period=y1",
             "/api/v1/market/cagr-ranking?metric=cash",
             "/api/v1/market/cagr-ranking?sort=return",
@@ -1343,8 +1343,8 @@ mod tests {
             .collect();
         assert_eq!(
             periods,
-            vec!["M3", "M6", "Y1", "Y1H", "Y2", "Y3", "Y5", "Y10"],
-            "個股端點必須回傳全部八個期間且依期間長度排序"
+            vec!["M3", "M6", "Y1", "Y1H", "Y2", "Y3", "Y5", "Y7", "Y10"],
+            "個股端點必須回傳全部九個期間且依期間長度排序"
         );
         assert!(
             json["items"]

--- a/src/interfaces/web/data_api/mod.rs
+++ b/src/interfaces/web/data_api/mod.rs
@@ -1170,12 +1170,12 @@ mod tests {
         // 結果，這條路徑仍會把排行 SQL（CTE、視窗函式、三個篩選、分頁）
         // 送進 PostgreSQL，語法或欄位錯誤會立刻現形。
         for path in [
-            "/api/v1/market/cagr-ranking?date=1990-01-02&period=Y1",
-            "/api/v1/market/cagr-ranking?date=1990-01-02&period=M3&sort=total_return",
-            "/api/v1/market/cagr-ranking?date=1990-01-02&period=Y3&metric=price&market=twse",
-            "/api/v1/market/cagr-ranking?date=1990-01-02&metric=reinvested&stock_industry_id=24",
-            "/api/v1/market/cagr-ranking?date=1990-01-02&keyword=%E5%8F%B0%E7%A9%8D&offset=10",
-            "/api/v1/market/cagr-ranking?date=1990-01-02&include_incomplete=false&limit=200",
+            "/api/v1/market/cagr-ranking?date=1990-01-03&period=Y1",
+            "/api/v1/market/cagr-ranking?date=1990-01-03&period=M3&sort=total_return",
+            "/api/v1/market/cagr-ranking?date=1990-01-03&period=Y3&metric=price&market=twse",
+            "/api/v1/market/cagr-ranking?date=1990-01-03&metric=reinvested&stock_industry_id=24",
+            "/api/v1/market/cagr-ranking?date=1990-01-03&keyword=%E5%8F%B0%E7%A9%8D&offset=10",
+            "/api/v1/market/cagr-ranking?date=1990-01-03&include_incomplete=false&limit=200",
         ] {
             let (status, json) = get(path.to_owned()).await;
             assert_eq!(status, StatusCode::OK, "{path} 應能在真實 schema 執行");
@@ -1187,11 +1187,15 @@ mod tests {
             assert_eq!(json["summary"]["positive_ratio"], "0.0000");
         }
 
-        let (status, json) = get("/api/v1/market/cagr-ranking?period=Y1&limit=50".to_owned()).await;
-        if status == StatusCode::NOT_FOUND {
-            println!("跳過 cagr_endpoints_db_semantics：stock_cagr 尚無計算結果");
-            return;
-        }
+        // 自行寫入一組計算結果再驗證有資料時的回應。早期版本改為「排程尚未
+        // 產出結果就跳過」，於是 CI 從未跑過表頭、名次、涵蓋統計與個股端點 ——
+        // 那正是這兩個 endpoint 的主體。資料一律用假代號與 1990-01-02，
+        // 結束時清除。
+        cagr_seed::cleanup().await;
+        cagr_seed::seed().await;
+
+        let (status, json) =
+            get("/api/v1/market/cagr-ranking?date=1990-01-02&period=Y1&limit=50".to_owned()).await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(json["period"], "Y1");
         assert_eq!(json["metric"], "total");
@@ -1204,7 +1208,17 @@ mod tests {
             assert!(value.is_string(), "{pointer} 必須序列化為字串");
         }
 
+        // 表頭的期初日與年數取自可算項目，不得因為有資料不足的列就變成 null。
+        assert_eq!(json["date"], "1990-01-02");
+        assert_eq!(json["base_date"], "1989-01-03");
+        assert!(json["years"].is_string());
+        assert_eq!(json["coverage"]["universe"], 3);
+        assert_eq!(json["coverage"]["counted"], 2);
+        assert_eq!(json["coverage"]["incomplete"], 1);
+        assert_eq!(json["total"], 3);
+
         let items = json["items"].as_array().expect("items array");
+        assert_eq!(items.len(), 3);
         let mut previous_rank = 0_i64;
         let mut seen_incomplete = false;
         for item in items {
@@ -1227,75 +1241,265 @@ mod tests {
             }
         }
 
-        // 全市場名次：套用產業篩選後，名次仍是未篩選的完整市場排名，
-        // 因此第一筆的 rank 只會 >= 未篩選時的第一筆。
-        if let Some(industry) = items
+        // 全市場名次：套用產業篩選後，名次仍是未篩選的完整市場排名。
+        let (status, filtered) = get(format!(
+            "/api/v1/market/cagr-ranking?date=1990-01-02&period=Y1&stock_industry_id={}&limit=50",
+            cagr_seed::INDUSTRY
+        ))
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            filtered["coverage"], json["coverage"],
+            "涵蓋統計不隨畫面篩選變動"
+        );
+        assert!(
+            filtered["total"].as_i64() <= json["total"].as_i64(),
+            "篩選後的 total 不可大於未篩選"
+        );
+        let filtered_ranks: Vec<Option<i64>> = filtered["items"]
+            .as_array()
+            .expect("items array")
             .iter()
-            .find(|item| item["rank"].as_i64() == Some(1))
-            .and_then(|item| item["stock_industry_id"].as_i64())
-        {
-            let (status, filtered) = get(format!(
-                "/api/v1/market/cagr-ranking?period=Y1&stock_industry_id={industry}&limit=50"
-            ))
-            .await;
-            assert_eq!(status, StatusCode::OK);
-            assert_eq!(
-                filtered["coverage"], json["coverage"],
-                "涵蓋統計不隨畫面篩選變動"
-            );
-            assert!(
-                filtered["total"].as_i64() <= json["total"].as_i64(),
-                "篩選後的 total 不可大於未篩選"
-            );
-            if let Some(first) = filtered["items"]
+            .map(|item| item["rank"].as_i64())
+            .collect();
+        assert_eq!(
+            filtered_ranks,
+            items
+                .iter()
+                .map(|item| item["rank"].as_i64())
+                .collect::<Vec<_>>(),
+            "篩選後名次不得重編"
+        );
+
+        // 市場篩選對應到 stock_exchange_market_id：上櫃篩選不含這批上市假股票。
+        let (status, tpex) =
+            get("/api/v1/market/cagr-ranking?date=1990-01-02&period=Y1&market=tpex".to_owned())
+                .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(tpex["total"], 0);
+
+        // 關鍵字比對代號與名稱。
+        let (status, keyword) = get(format!(
+            "/api/v1/market/cagr-ranking?date=1990-01-02&period=Y1&keyword={}",
+            cagr_seed::TOP_SYMBOL
+        ))
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(keyword["total"], 1);
+
+        // include_incomplete = false 時資料不足的列整列消失。
+        let (status, complete_only) = get(
+            "/api/v1/market/cagr-ranking?date=1990-01-02&period=Y1&include_incomplete=false"
+                .to_owned(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(complete_only["total"], 2);
+        assert!(
+            complete_only["items"]
                 .as_array()
-                .and_then(|list| list.first())
-                .and_then(|item| item["rank"].as_i64())
-            {
-                assert!(first >= 1, "篩選後的名次仍是全市場名次");
-            }
-        }
+                .expect("items array")
+                .iter()
+                .all(|item| item["rank"].is_i64())
+        );
 
         // Y10 + price 由 handler 在任何 SQL 之前擋下。
         let (status, _) =
             get("/api/v1/market/cagr-ranking?period=Y10&metric=price".to_owned()).await;
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
 
-        // Y10 的揭露旗標必須為 true。
-        let (status, json) = get("/api/v1/market/cagr-ranking?period=Y10&limit=1".to_owned()).await;
+        // Y10 的揭露旗標必須為 true，且長期間不提供純價格口徑（欄位為 null）。
+        let (status, json) =
+            get("/api/v1/market/cagr-ranking?date=1990-01-02&period=Y10&limit=1".to_owned()).await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(json["coverage"]["survivorship_note"], true);
 
         // 個股端點：未知代號 404；已知代號回傳全部八個期間且由短至長。
         let (status, _) = get("/api/v1/market/cagr-ranking/NO_SUCH_SYMBOL".to_owned()).await;
         assert_eq!(status, StatusCode::NOT_FOUND);
-        if let Some(symbol) = items
-            .first()
-            .and_then(|item| item["stock_symbol"].as_str())
-            .map(str::to_owned)
-        {
-            let (status, json) = get(format!("/api/v1/market/cagr-ranking/{symbol}")).await;
-            assert_eq!(status, StatusCode::OK);
-            assert_eq!(json["stock_symbol"], symbol);
-            let periods: Vec<&str> = json["items"]
+
+        // 代號存在但該基準日沒有計算結果 —— 與「代號打錯」同為 404，但走的是
+        // 另一條分支。
+        let (status, _) = get(format!(
+            "/api/v1/market/cagr-ranking/{}?date=1990-01-03",
+            cagr_seed::TOP_SYMBOL
+        ))
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+
+        let (status, json) = get(format!(
+            "/api/v1/market/cagr-ranking/{}?date=1990-01-02",
+            cagr_seed::TOP_SYMBOL
+        ))
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["stock_symbol"], cagr_seed::TOP_SYMBOL);
+        assert_eq!(json["principal"], 10_000);
+        let periods: Vec<&str> = json["items"]
+            .as_array()
+            .expect("items array")
+            .iter()
+            .map(|item| item["period"].as_str().expect("period string"))
+            .collect();
+        assert_eq!(
+            periods,
+            vec!["M3", "M6", "Y1", "Y1H", "Y2", "Y3", "Y5", "Y10"],
+            "個股端點必須回傳全部八個期間且依期間長度排序"
+        );
+        assert!(
+            json["items"]
                 .as_array()
                 .expect("items array")
                 .iter()
-                .map(|item| item["period"].as_str().expect("period string"))
+                .all(|item| item["rank"].is_null()),
+            "個股端點的項目不應有名次"
+        );
+
+        // 指定 price 口徑時，長期間該口徑為 null 但列仍在。
+        let (status, price) = get(format!(
+            "/api/v1/market/cagr-ranking/{}?date=1990-01-02&metric=price",
+            cagr_seed::TOP_SYMBOL
+        ))
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let long_period = price["items"]
+            .as_array()
+            .expect("items array")
+            .iter()
+            .find(|item| item["period"] == "Y10")
+            .expect("Y10 應在清單中");
+        assert!(long_period["cagr_pct"].is_null(), "長期間不提供純價格口徑");
+
+        cagr_seed::cleanup().await;
+    }
+
+    /// `cagr_endpoints_db_semantics` 專用的測試資料。
+    ///
+    /// 代號一律以 `79979` 開頭（真實市場不存在），基準日固定 1990-01-02，
+    /// 遠早於本功能上線，不會與正式資料互相干擾。
+    #[cfg(feature = "integration-tests")]
+    mod cagr_seed {
+        use chrono::NaiveDate;
+        use rust_decimal_macros::dec;
+
+        use crate::domain::performance::{
+            CagrPeriod, CagrRepository, StockCagr, entity::SimulationOutcome,
+        };
+        use crate::infra::database;
+        use crate::infra::database::repository::performance::PgCagrRepository;
+
+        /// 名次第一的假代號，同時用於個股端點與關鍵字篩選。
+        pub(super) const TOP_SYMBOL: &str = "79979E1";
+        const SECOND_SYMBOL: &str = "79979E2";
+        const INCOMPLETE_SYMBOL: &str = "79979E3";
+        /// 水泥工業，`stock_industry.sql` 已預先建立。
+        pub(super) const INDUSTRY: i32 = 1;
+        /// 上市（twse）；`cagr_market_id` 把 "twse" 對應到 2。
+        const MARKET: i32 = 2;
+
+        fn symbols() -> Vec<String> {
+            vec![
+                TOP_SYMBOL.to_string(),
+                SECOND_SYMBOL.to_string(),
+                INCOMPLETE_SYMBOL.to_string(),
+            ]
+        }
+
+        fn base_date() -> NaiveDate {
+            NaiveDate::from_ymd_opt(1990, 1, 2).expect("測試日期應合法")
+        }
+
+        fn record(symbol: &str, period: CagrPeriod, cagr: rust_decimal::Decimal) -> StockCagr {
+            let outcome = SimulationOutcome {
+                end_shares: dec!(100.5),
+                cash_received: dec!(250.0),
+                end_value: dec!(12000.0),
+                total_return_pct: dec!(20.0),
+                cagr_pct: cagr,
+            };
+            StockCagr {
+                date: base_date(),
+                stock_symbol: symbol.to_string(),
+                period,
+                base_date: NaiveDate::from_ymd_opt(1989, 1, 3),
+                base_price: Some(dec!(100.0)),
+                end_price: Some(dec!(119.4)),
+                years: Some(dec!(1.0)),
+                // 與計算層一致：長期間不提供純價格口徑。
+                price: period.supports_price_metric().then_some(outcome),
+                total: Some(outcome),
+                reinvested: Some(outcome),
+                first_quote_date: NaiveDate::from_ymd_opt(1988, 1, 4),
+                shortfall_days: Some(0),
+                data_complete: true,
+                has_anomaly: false,
+                dividend_events: 2,
+            }
+        }
+
+        fn incomplete(symbol: &str, period: CagrPeriod) -> StockCagr {
+            StockCagr {
+                date: base_date(),
+                stock_symbol: symbol.to_string(),
+                period,
+                base_date: None,
+                base_price: None,
+                end_price: None,
+                years: None,
+                price: None,
+                total: None,
+                reinvested: None,
+                first_quote_date: NaiveDate::from_ymd_opt(1989, 6, 1),
+                shortfall_days: None,
+                data_complete: false,
+                has_anomaly: true,
+                dividend_events: 0,
+            }
+        }
+
+        pub(super) async fn seed() {
+            for (index, symbol) in symbols().iter().enumerate() {
+                let _ = sqlx::query(
+                    r#"INSERT INTO stocks ("SecurityCode", "Name", stock_symbol, stock_industry_id,
+                                           stock_exchange_market_id, "SuspendListing")
+                       VALUES ($1, $2, $1, $3, $4, false)
+                       ON CONFLICT (stock_symbol) DO UPDATE
+                           SET "Name" = excluded."Name",
+                               stock_industry_id = excluded.stock_industry_id,
+                               stock_exchange_market_id = excluded.stock_exchange_market_id"#,
+                )
+                .bind(symbol)
+                .bind(format!("測試股{}", index + 1))
+                .bind(INDUSTRY)
+                .bind(MARKET)
+                .execute(database::get_connection())
+                .await;
+            }
+
+            // 名次第一的個股寫滿八個期間，供個股端點驗證排序；
+            // 另外兩檔只寫 Y1，構成「可算 2 檔 + 資料不足 1 檔」的母體。
+            let mut records: Vec<StockCagr> = CagrPeriod::ALL
+                .into_iter()
+                .map(|period| record(TOP_SYMBOL, period, dec!(30)))
                 .collect();
-            assert_eq!(
-                periods,
-                vec!["M3", "M6", "Y1", "Y1H", "Y2", "Y3", "Y5", "Y10"],
-                "個股端點必須回傳全部八個期間且依期間長度排序"
-            );
-            assert!(
-                json["items"]
-                    .as_array()
-                    .expect("items array")
-                    .iter()
-                    .all(|item| item["rank"].is_null()),
-                "個股端點的項目不應有名次"
-            );
+            records.push(record(SECOND_SYMBOL, CagrPeriod::Y1, dec!(10)));
+            records.push(incomplete(INCOMPLETE_SYMBOL, CagrPeriod::Y1));
+
+            PgCagrRepository::new()
+                .save_batch(&records)
+                .await
+                .expect("寫入測試用 CAGR 結果");
+        }
+
+        pub(super) async fn cleanup() {
+            let _ = sqlx::query("DELETE FROM stock_cagr WHERE stock_symbol = ANY($1)")
+                .bind(symbols())
+                .execute(database::get_connection())
+                .await;
+            let _ = sqlx::query("DELETE FROM stocks WHERE stock_symbol = ANY($1)")
+                .bind(symbols())
+                .execute(database::get_connection())
+                .await;
         }
     }
 


### PR DESCRIPTION
## 摘要

新增「每日各期間年化報酬率（CAGR）」功能：每天以固定投入 10,000 元模擬，計算全市場每檔股票在 **3M / 6M / 1Y / 1Y6M / 2Y / 3Y / 5Y / 10Y** 八個期間的報酬與 CAGR，寫入新表 `stock_cagr`，並經 Data API 曝露排行與個股查詢。

## 為什麼不直接算價格比值

`DailyQuotes` 存的是原始收盤價而非還原股價，直接取 P1/P0 會低估除權息過的股票。改以「期初用當時真實價買 `10000/P0` 股，配股加股數、配息加現金，期末以真實價結算」模擬 — 數學上等價於還原股價法，且不需重建還原係數。

## 分層

| 層 | 內容 |
|---|---|
| `domain/performance` | `CagrPeriod`(8 期間)、`CagrMetric`(3 口徑)、`StockCagr`、純函式 `simulator`（無 I/O，14 項單元測試）、`CagrRepository`、`CagrSourceRepository`、排行 `query` |
| `app/calculation/cagr` | 全市場統一對齊期初交易日 + 30 天寬限；股利事件單次撈齊後於記憶體分派；再投入價格以 `UNNEST` 批次查詢 |
| `infra` | `stock_cagr` 表（三條口徑各自的排行 partial index）、row model、`PgCagrRepository`、`PgCagrSourceRepository` |
| `interfaces/web/data_api` | `GET /api/v1/market/cagr-ranking`、`GET /api/v1/market/cagr-ranking/{stock_symbol}` |
| `app/scheduler` | 05:40（台北時間），排在 21:00 股利回補與 05:00–05:30 各項回補之後 |

## 依 2026-08-07 對正式庫唯讀驗證所做的決定

- 報價自 2012 年起完整，八個期間全部成立；**Y5/Y10 涵蓋率僅 62.6% / 55.7%**，標記為不預設曝露，且必須揭露樣本涵蓋與存活者偏誤。
- `dividend` 表有 1,619 組「年度彙總列」與「季度明細列」並存，查詢以 `has_detail` 去重，否則季配息股股利會被計算兩次。
- 除權息日欄位含 `'-'`（17,553 筆）、`'尚未公布'`，甚至 `'1.39%'` 等百分比字串 — 一律取原始字串在 Rust 端解析，**絕不在 SQL 做 `::date` 轉型**。
- 近十年每年皆有 134–216 檔配股，故長期間停用純價格口徑。
- 減資／分割偵測門檻由 11% 校準為 **30%**：11% 會標記到全市場 45% 的股票而失去意義，誤判主要來自興櫃／ETN 無漲跌幅限制與除息日未登錄。異常事件帶日期回傳，由各期間各自判定，避免跨期間共用造成語義錯誤。

資料不足者仍寫入一列（`data_complete=false`、數值欄位為 `NULL` 而非 `0`），使 `coverage.universe` 能正確反映母體，涵蓋率不被高估。

## 測試

- `domain/performance/simulator` 14 項純單元測試（無 I/O，不需 DB）。
- `etc/sql/stock_cagr.sql` 已加入，CI 測試 DB 會據此建表。

## 尚未涵蓋

- 排程首次實跑（05:40）與實際涵蓋率觀測。
- MCP 端（`stock-mcp-go`）尚未新增對應工具。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
