### PR TITLE
Refactor(database): Ensure data consistency in `save_received_dividend`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1291,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2813,7 +2813,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2871,7 +2871,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3594,7 +3594,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4297,7 +4297,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/domain/yield_rank/entity.rs
+++ b/src/domain/yield_rank/entity.rs
@@ -43,3 +43,35 @@ impl YieldRank {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rust_decimal_macros::dec;
+
+    use super::*;
+
+    /// 工廠方法必須原樣保留各欄位，欄位順序寫錯會讓兩個 i64 序號互換而不易察覺。
+    #[test]
+    fn new_keeps_all_fields() {
+        let date = NaiveDate::from_ymd_opt(2026, 8, 21).unwrap();
+        let rank = YieldRank::new(date, "2330".to_string(), 101, 202, dec!(2.35));
+
+        assert_eq!(rank.date, date);
+        assert_eq!(rank.security_code, "2330");
+        assert_eq!(rank.daily_quotes_serial, 101);
+        assert_eq!(rank.dividend_serial, 202);
+        assert_eq!(rank.r#yield, dec!(2.35));
+    }
+
+    /// 同值實體必須相等（PartialEq 供去重與測試斷言使用）。
+    #[test]
+    fn equality_compares_by_value() {
+        let date = NaiveDate::from_ymd_opt(2026, 8, 21).unwrap();
+        let one = YieldRank::new(date, "2330".to_string(), 101, 202, dec!(2.35));
+        let another = YieldRank::new(date, "2330".to_string(), 101, 202, dec!(2.35));
+        let different_yield = YieldRank::new(date, "2330".to_string(), 101, 202, dec!(2.36));
+
+        assert_eq!(one, another);
+        assert_ne!(one, different_yield);
+    }
+}

--- a/src/infra/crawler/bigdatacloud/mod.rs
+++ b/src/infra/crawler/bigdatacloud/mod.rs
@@ -17,10 +17,11 @@ struct ApiResponse {
     pub ip_type: String,
 }
 
-/// 取得目前的IP
-pub async fn visit() -> Result<String> {
-    let url = DDNS_URL.get_or_init(|| format!("https://{host}/data/client-ip", host = HOST,));
-    let res = util::http::get_json::<ApiResponse>(url).await?;
+/// 從 API 回應取出公開 IP。
+///
+/// 純函式（不做網路 I/O）：`ipString` 為空字串時代表來源沒給有效值，
+/// 必須報錯，避免把空字串當成 IP 傳給後續的 DDNS 更新流程。
+fn extract_ip(res: ApiResponse) -> Result<String> {
     if !res.ip_string.is_empty() {
         return Ok(res.ip_string);
     }
@@ -28,11 +29,47 @@ pub async fn visit() -> Result<String> {
     Err(anyhow!("can't get public ip from {}", HOST))
 }
 
+/// 取得目前的IP
+pub async fn visit() -> Result<String> {
+    let url = DDNS_URL.get_or_init(|| format!("https://{host}/data/client-ip", host = HOST,));
+    let res = util::http::get_json::<ApiResponse>(url).await?;
+
+    extract_ip(res)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::infra::crawler::log_public_ip_visit_test;
 
     use super::*;
+
+    /// 驗證 serde 欄位對應：`ipString` / `ipType` 需要 rename，多餘欄位要被忽略。
+    #[test]
+    fn api_response_deserializes_official_shape() {
+        let body = r#"{
+            "ipString": "203.0.113.7",
+            "ipType": "v4",
+            "ipNumeric": "3405803783"
+        }"#;
+        let res: ApiResponse = serde_json::from_str(body).unwrap();
+
+        assert_eq!(res.ip_string, "203.0.113.7");
+        assert_eq!(res.ip_type, "v4");
+        assert_eq!(extract_ip(res).unwrap(), "203.0.113.7");
+    }
+
+    /// `ipString` 為空字串時不可當成有效 IP 回傳。
+    #[test]
+    fn extract_ip_rejects_empty_ip_string() {
+        let res = ApiResponse {
+            ip_string: String::new(),
+            ip_type: "v4".to_string(),
+        };
+        let err = extract_ip(res).expect_err("empty ipString should be an error");
+
+        assert!(err.to_string().contains("can't get public ip"));
+        assert!(err.to_string().contains(HOST));
+    }
 
     #[tokio::test]
     #[ignore = "live test：連線真實外部網站，需要時手動執行"]

--- a/src/infra/crawler/fbs/annual_profit.rs
+++ b/src/infra/crawler/fbs/annual_profit.rs
@@ -6,15 +6,20 @@ use crate::infra::crawler::{fbs::HOST, share, share::AnnualProfitFetcher};
 /// 富邦證券年度獲利資料來源型別。
 pub struct Fbs {}
 
-/// 抓取年度股利資料
-pub async fn visit(stock_symbol: &str) -> Result<Vec<share::AnnualProfit>> {
-    let url = format!(
+/// 組出富邦證券年度獲利頁面的網址。
+///
+/// 抽成純函式讓網址格式可被單元測試鎖定，避免改版時悄悄打錯路徑。
+fn build_url(stock_symbol: &str) -> String {
+    format!(
         "https://{host}/z/zc/zcdj_{stock_symbol}.djhtm",
         host = HOST,
         stock_symbol = stock_symbol,
-    );
+    )
+}
 
-    Ok(share::fetch_annual_profits(&url, stock_symbol).await?)
+/// 抓取年度股利資料
+pub async fn visit(stock_symbol: &str) -> Result<Vec<share::AnnualProfit>> {
+    Ok(share::fetch_annual_profits(&build_url(stock_symbol), stock_symbol).await?)
 }
 
 #[async_trait]
@@ -27,6 +32,15 @@ impl AnnualProfitFetcher for Fbs {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// 網址一旦改錯就會整個來源失效，這裡把格式鎖定住。
+    #[test]
+    fn build_url_points_to_annual_profit_page() {
+        assert_eq!(
+            build_url("2330"),
+            "https://fubon-ebrokerdj.fbs.com.tw/z/zc/zcdj_2330.djhtm"
+        );
+    }
 
     #[tokio::test]
     #[ignore = "live test：連線真實外部網站，需要時手動執行"]

--- a/src/infra/crawler/fugle/price.rs
+++ b/src/infra/crawler/fugle/price.rs
@@ -91,60 +91,75 @@ impl RateLimiter {
             self.blocked_until = None;
         }
     }
+
+    /// 以指定時間點嘗試取得一個配額。
+    ///
+    /// 時間由參數傳入而非直接讀時鐘，因此這是可被單元測試完整驗證的純邏輯：
+    /// 測試能自行推進「現在」來覆蓋滑動視窗、封鎖與解除封鎖等分支。
+    ///
+    /// # 回傳
+    /// * `Ok(())` - 取得配額，呼叫端可以送出請求。
+    /// * `Err` - 仍在冷卻期或視窗內已達上限，呼叫端應改用下一個備援來源。
+    fn try_acquire(&mut self, now: Instant) -> Result<()> {
+        // 每次進來都先清理：
+        // 1. 移除視窗外（超過 60 秒）的舊請求
+        // 2. 若封鎖時間已過，解除封鎖
+        self.cleanup(now);
+
+        // 若目前仍在冷卻期，直接拒絕本次 Fugle 呼叫，
+        // 讓外層備援邏輯立即切到下一個網站。
+        if let Some(until) = self.blocked_until {
+            return Err(anyhow!(
+                "Fugle local rate limit active, retry after {:?}",
+                until.saturating_duration_since(now)
+            ));
+        }
+
+        // 滑動視窗內的請求數已達上限時：
+        // 1. 以「最早那筆請求 + 視窗長度」作為下次可恢復時間
+        // 2. 進入暫時封鎖狀態，避免後續短時間內持續打到 Fugle
+        // 3. 本次直接回錯，交給下一個備援來源處理
+        if self.requests.len() >= LOCAL_RATE_LIMIT_PER_MINUTE {
+            let next_reset = self
+                .requests
+                .front()
+                .copied()
+                .map(|oldest| oldest + RATE_LIMIT_WINDOW)
+                .unwrap_or(now + RATE_LIMIT_WINDOW);
+            self.blocked_until = Some(next_reset);
+
+            return Err(anyhow!(
+                "Fugle local rate limit reached ({LOCAL_RATE_LIMIT_PER_MINUTE}/min)"
+            ));
+        }
+
+        // 尚未達上限時，記錄本次請求時間，
+        // 代表這次 Fugle 配額已被占用。
+        self.requests.push_back(now);
+        Ok(())
+    }
+
+    /// 自指定時間點起強制進入一個視窗長度的冷卻期。
+    fn block_from(&mut self, now: Instant) {
+        self.blocked_until = Some(now + RATE_LIMIT_WINDOW);
+    }
 }
 
 /// 嘗試為 Fugle 取得一個本地限流配額。
 ///
 /// 若已達本地上限，直接回傳錯誤，讓外層備援鏈切到下一個網站。
 fn acquire_rate_limit_slot() -> Result<()> {
-    let now = Instant::now();
     // 先取得全域限流器鎖，確保多執行緒下的計數與封鎖狀態一致。
-    let mut limiter = RATE_LIMITER
+    RATE_LIMITER
         .lock()
-        .map_err(|_| anyhow!("Failed to lock Fugle rate limiter"))?;
-
-    // 每次進來都先清理：
-    // 1. 移除視窗外（超過 60 秒）的舊請求
-    // 2. 若封鎖時間已過，解除封鎖
-    limiter.cleanup(now);
-
-    // 若目前仍在冷卻期，直接拒絕本次 Fugle 呼叫，
-    // 讓外層備援邏輯立即切到下一個網站。
-    if let Some(until) = limiter.blocked_until {
-        return Err(anyhow!(
-            "Fugle local rate limit active, retry after {:?}",
-            until.saturating_duration_since(now)
-        ));
-    }
-
-    // 滑動視窗內的請求數已達上限時：
-    // 1. 以「最早那筆請求 + 視窗長度」作為下次可恢復時間
-    // 2. 進入暫時封鎖狀態，避免後續短時間內持續打到 Fugle
-    // 3. 本次直接回錯，交給下一個備援來源處理
-    if limiter.requests.len() >= LOCAL_RATE_LIMIT_PER_MINUTE {
-        let next_reset = limiter
-            .requests
-            .front()
-            .copied()
-            .map(|oldest| oldest + RATE_LIMIT_WINDOW)
-            .unwrap_or(now + RATE_LIMIT_WINDOW);
-        limiter.blocked_until = Some(next_reset);
-
-        return Err(anyhow!(
-            "Fugle local rate limit reached ({LOCAL_RATE_LIMIT_PER_MINUTE}/min)"
-        ));
-    }
-
-    // 尚未達上限時，記錄本次請求時間，
-    // 代表這次 Fugle 配額已被占用。
-    limiter.requests.push_back(now);
-    Ok(())
+        .map_err(|_| anyhow!("Failed to lock Fugle rate limiter"))?
+        .try_acquire(Instant::now())
 }
 
 /// 當上游已回報限流（例如 HTTP 429）時，強制進入冷卻期。
 fn mark_remote_rate_limited() {
     if let Ok(mut limiter) = RATE_LIMITER.lock() {
-        limiter.blocked_until = Some(Instant::now() + RATE_LIMIT_WINDOW);
+        limiter.block_from(Instant::now());
     }
 }
 
@@ -279,6 +294,92 @@ mod tests {
         assert_eq!(quote.change, Some(15.0));
         assert_eq!(quote.change_percent, Some(1.52));
         assert_eq!(quote.last_trade.as_ref().unwrap().price, 1002.0);
+    }
+
+    /// 視窗內未達上限時，每次請求都應取得配額並被記錄下來。
+    #[test]
+    fn rate_limiter_allows_requests_below_limit() {
+        let mut limiter = RateLimiter::default();
+        let now = Instant::now();
+
+        for i in 0..LOCAL_RATE_LIMIT_PER_MINUTE {
+            limiter
+                .try_acquire(now + Duration::from_millis(i as u64))
+                .unwrap_or_else(|why| panic!("第 {i} 次請求不該被限流：{why:?}"));
+        }
+
+        assert_eq!(limiter.requests.len(), LOCAL_RATE_LIMIT_PER_MINUTE);
+        assert!(limiter.blocked_until.is_none(), "未超量時不該進入冷卻期");
+    }
+
+    /// 一分鐘內達到上限後，下一次請求要被擋下並進入冷卻期。
+    #[test]
+    fn rate_limiter_blocks_after_reaching_limit() {
+        let mut limiter = RateLimiter::default();
+        let start = Instant::now();
+
+        for i in 0..LOCAL_RATE_LIMIT_PER_MINUTE {
+            limiter
+                .try_acquire(start + Duration::from_millis(i as u64))
+                .expect("額度內不該被限流");
+        }
+
+        let err = limiter
+            .try_acquire(start + Duration::from_millis(1_000))
+            .expect_err("超過上限必須回錯，讓外層切換備援站點");
+        assert!(err.to_string().contains("local rate limit reached"));
+
+        // 冷卻截止時間應是「最早那筆請求 + 視窗長度」。
+        assert_eq!(limiter.blocked_until, Some(start + RATE_LIMIT_WINDOW));
+
+        // 冷卻期內再次嘗試，錯誤訊息要換成 active（附剩餘等待時間）。
+        let err = limiter
+            .try_acquire(start + Duration::from_secs(30))
+            .expect_err("冷卻期內必須持續拒絕");
+        assert!(err.to_string().contains("local rate limit active"));
+    }
+
+    /// 視窗過完後舊紀錄要被清掉，Fugle 應恢復可用。
+    #[test]
+    fn rate_limiter_recovers_after_window_elapsed() {
+        let mut limiter = RateLimiter::default();
+        let start = Instant::now();
+
+        for i in 0..LOCAL_RATE_LIMIT_PER_MINUTE {
+            limiter
+                .try_acquire(start + Duration::from_millis(i as u64))
+                .expect("額度內不該被限流");
+        }
+        limiter
+            .try_acquire(start + Duration::from_millis(1_000))
+            .expect_err("先讓它進入冷卻期");
+
+        // 視窗結束後：封鎖解除、舊請求清空，重新可以取得配額。
+        limiter
+            .try_acquire(start + RATE_LIMIT_WINDOW + Duration::from_secs(1))
+            .expect("視窗過後應恢復可用");
+
+        assert!(limiter.blocked_until.is_none(), "過期封鎖必須被解除");
+        assert_eq!(limiter.requests.len(), 1, "視窗外的舊紀錄應被清掉");
+    }
+
+    /// 上游回 429 時強制冷卻一個視窗，且冷卻結束後可自行恢復。
+    #[test]
+    fn rate_limiter_block_from_marks_remote_rate_limited() {
+        let mut limiter = RateLimiter::default();
+        let now = Instant::now();
+
+        limiter.block_from(now);
+        assert_eq!(limiter.blocked_until, Some(now + RATE_LIMIT_WINDOW));
+
+        let err = limiter
+            .try_acquire(now + Duration::from_secs(1))
+            .expect_err("遠端限流期間必須跳過 Fugle");
+        assert!(err.to_string().contains("local rate limit active"));
+
+        limiter
+            .try_acquire(now + RATE_LIMIT_WINDOW)
+            .expect("冷卻期屆滿即可恢復");
     }
 
     /// 驗證即時價的取值優先序：

--- a/src/infra/crawler/ipinfo/mod.rs
+++ b/src/infra/crawler/ipinfo/mod.rs
@@ -8,15 +8,38 @@ static DDNS_URL: OnceLock<String> = OnceLock::new();
 
 const HOST: &str = "ipinfo.io";
 
+/// 組出 ipinfo 純文字 IP 端點的網址。
+///
+/// 抽成純函式讓網址格式可被單元測試鎖定（`/ip` 回傳純文字，不是 JSON）。
+fn build_url() -> String {
+    format!("https://{host}/ip", host = HOST,)
+}
+
 /// 取得目前的IP
 pub async fn visit() -> Result<String> {
-    let url = DDNS_URL.get_or_init(|| format!("https://{host}/ip", host = HOST,));
+    let url = DDNS_URL.get_or_init(build_url);
     util::http::get(url, None).await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// 端點打錯會拿到 HTML 而非純文字 IP，這裡把網址格式鎖定住。
+    #[test]
+    fn build_url_points_to_plain_text_ip_endpoint() {
+        assert_eq!(build_url(), "https://ipinfo.io/ip");
+    }
+
+    /// `DDNS_URL` 只初始化一次，重複呼叫 `visit` 必須拿到同一個網址。
+    #[test]
+    fn ddns_url_is_initialized_once() {
+        let first = DDNS_URL.get_or_init(build_url).clone();
+        let second = DDNS_URL.get_or_init(|| "https://should-not-be-used.test".to_string());
+
+        assert_eq!(first, "https://ipinfo.io/ip");
+        assert_eq!(&first, second);
+    }
 
     #[tokio::test]
     #[ignore = "live test：連線真實外部網站，需要時手動執行"]

--- a/src/infra/crawler/winvest/price.rs
+++ b/src/infra/crawler/winvest/price.rs
@@ -89,7 +89,16 @@ async fn fetch_data(stock_symbol: &str) -> Result<QueryDayPriceResponse> {
     params.insert("inModel[SymbolCode]", stock_symbol);
 
     let response_text = util::http::post(&url, None, Some(params)).await?;
-    let response: QueryDayPriceResponse = serde_json::from_str(&response_text).map_err(|why| {
+
+    parse_query_day_price(&url, &response_text)
+}
+
+/// 解析並驗證 `QueryDayPrice` 的回應內容。
+///
+/// 這是一個純函式（不做網路 I/O），可直接用固定 JSON 樣本驗證：
+/// 解析失敗、`errMsg` 非空、兩組報價欄位同時缺失，都必須明確報錯。
+fn parse_query_day_price(url: &str, response_text: &str) -> Result<QueryDayPriceResponse> {
+    let response: QueryDayPriceResponse = serde_json::from_str(response_text).map_err(|why| {
         let preview = response_text.chars().take(300).collect::<String>();
         anyhow!(
             "Failed to parse QueryDayPrice response from {} because {:?}. body preview: {}",
@@ -293,11 +302,102 @@ mod tests {
         assert_eq!(price, 1885.0);
     }
 
+    /// 沒有任何一列有可解析價格時要回 None，不能誤把標題列當價格。
+    #[test]
+    fn extract_last_price_returns_none_when_no_numeric_row() {
+        let stock_list_price = vec![
+            vec!["KlineDatetime".to_string(), "ClosePrice".to_string()],
+            vec!["09:00".to_string()],
+        ];
+
+        assert!(extract_last_price_from_stock_list(&stock_list_price).is_none());
+    }
+
     #[test]
     /// 驗證當 API 的 `ChangeRate` 為 0 時，會用昨收回推並四捨五入到小數第 2 位。
     fn test_compute_change_range_fallback_by_yesterday_close() {
         let change_range = compute_change_range(-20.0, Some(1900.0), Some(0.0));
         assert_eq!(change_range, -1.05);
+    }
+
+    /// `ChangeRate` 有效時直接採用，不做回推。
+    #[test]
+    fn compute_change_range_prefers_valid_api_rate() {
+        assert_eq!(
+            compute_change_range(-15.0, Some(1900.0), Some(-0.79)),
+            -0.79
+        );
+        // 平盤（change 為 0）時，rate 為 0 是合法值而非異常，應原樣採用。
+        assert_eq!(compute_change_range(0.0, Some(1900.0), Some(0.0)), 0.0);
+    }
+
+    /// API 未提供 `ChangeRate` 時，用昨收回推。
+    #[test]
+    fn compute_change_range_computes_from_yesterday_close_when_rate_missing() {
+        assert_eq!(compute_change_range(19.0, Some(1900.0), None), 1.0);
+    }
+
+    /// 昨收缺失或為 0 時不可除以零，一律回 0。
+    #[test]
+    fn compute_change_range_returns_zero_without_usable_yesterday_close() {
+        assert_eq!(compute_change_range(-20.0, None, None), 0.0);
+        assert_eq!(compute_change_range(-20.0, Some(0.0), Some(0.0)), 0.0);
+        assert_eq!(compute_change_range(-20.0, None, Some(0.0)), 0.0);
+    }
+
+    /// `ChangeRate` 為 NaN 之類的非有限值時，要退回昨收回推而不是把 NaN 傳出去。
+    #[test]
+    fn compute_change_range_falls_back_when_rate_is_not_finite() {
+        assert_eq!(
+            compute_change_range(-20.0, Some(1900.0), Some(f64::NAN)),
+            -1.05
+        );
+    }
+
+    /// 回應為非 JSON（例如被導到錯誤頁）時，錯誤訊息要帶上內容預覽方便排查。
+    #[test]
+    fn parse_query_day_price_rejects_non_json_body() {
+        let err = parse_query_day_price("https://example.test/QueryDayPrice", "<html>503</html>")
+            .expect_err("non-JSON body should be an error");
+
+        assert!(err.to_string().contains("Failed to parse QueryDayPrice"));
+        assert!(err.to_string().contains("body preview: <html>503</html>"));
+    }
+
+    /// API 明確回報 `errMsg` 時必須報錯，不能把空報價當成正常結果。
+    #[test]
+    fn parse_query_day_price_rejects_non_empty_err_msg() {
+        let body = r#"{ "StockListPrice": [], "StockLastKline": null, "errMsg": " 查無此代碼 " }"#;
+        let err = parse_query_day_price("https://example.test/QueryDayPrice", body)
+            .expect_err("errMsg should be an error");
+
+        assert!(err.to_string().contains("errMsg is 查無此代碼"));
+    }
+
+    /// 兩組報價欄位同時缺失代表這次回應沒有可用資料。
+    #[test]
+    fn parse_query_day_price_rejects_empty_payload() {
+        let err = parse_query_day_price("https://example.test/QueryDayPrice", r#"{}"#)
+            .expect_err("empty payload should be an error");
+
+        assert!(
+            err.to_string()
+                .contains("StockLastKline and StockListPrice are empty")
+        );
+    }
+
+    /// 正常回應（含空字串 `errMsg`）要能通過驗證。
+    #[test]
+    fn parse_query_day_price_accepts_valid_payload() {
+        let body = r#"{
+            "StockListPrice": [["KlineDatetime", "ClosePrice"], ["09:00", "1880"]],
+            "StockLastKline": { "ClosePrice": 1885.0, "Change": -15.0,
+                                "YesterdayClosePrice": 1900.0, "ChangeRate": -0.79 },
+            "errMsg": ""
+        }"#;
+        let response = parse_query_day_price("https://example.test/QueryDayPrice", body).unwrap();
+
+        assert_eq!(response.stock_last_kline.unwrap().close_price, 1885.0);
     }
 
     #[tokio::test]

--- a/src/infra/crawler/yuanta/price.rs
+++ b/src/infra/crawler/yuanta/price.rs
@@ -47,15 +47,22 @@ struct Data {
     trend_percentage: f64,
 }
 
-/// 向元大即時報價 API 取得指定股票代碼的原始資料。
-async fn fetch_data(stock_symbol: &str) -> Result<Data> {
-    let url = format!(
+/// 組出元大即時報價 API 的查詢網址。
+///
+/// 抽成純函式讓網址格式可被單元測試鎖定，避免改版時悄悄打錯端點。
+fn build_url(stock_symbol: &str) -> String {
+    format!(
         "https://{host}/prod/yesidmz/api/basic/currentstock?symbol={symbol}",
         host = HOST,
         symbol = stock_symbol
-    );
-    let response = util::http::get_json::<Response>(&url).await?;
+    )
+}
 
+/// 檢查 API 回應狀態並取出報價資料。
+///
+/// 這是一個純函式（不做網路 I/O），可直接用固定 JSON 樣本驗證：
+/// `status` 非 `0` 時視為來源回報失敗，必須明確報錯而不是回傳空資料。
+fn parse_response(url: &str, response: Response) -> Result<Data> {
     if response.status != 0 {
         return Err(anyhow!(
             "Failed to fetch_data from {url} because status is {}",
@@ -64,6 +71,16 @@ async fn fetch_data(stock_symbol: &str) -> Result<Data> {
     }
 
     Ok(response.data)
+}
+
+/// 向元大即時報價 API 取得指定股票代碼的原始資料。
+///
+/// 只負責 HTTP 抓取，狀態檢查與取值交給 [`parse_response`]。
+async fn fetch_data(stock_symbol: &str) -> Result<Data> {
+    let url = build_url(stock_symbol);
+    let response = util::http::get_json::<Response>(&url).await?;
+
+    parse_response(&url, response)
 }
 
 #[async_trait]
@@ -108,6 +125,61 @@ impl StockInfo for Yuanta {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// 樣本取自元大 API 的實際回應形狀（僅保留本模組會用到的欄位）。
+    const SUCCESS_BODY: &str = r#"{
+        "status": 0,
+        "data": {
+            "deal": 1435.0,
+            "trend": -15.0,
+            "trendPercentage": -1.03,
+            "name": "台積電"
+        }
+    }"#;
+
+    /// 網址一旦改錯就會整個來源失效，這裡把格式鎖定住。
+    #[test]
+    fn build_url_points_to_currentstock_endpoint() {
+        assert_eq!(
+            build_url("2330"),
+            "https://ytdf.yuanta.com.tw/prod/yesidmz/api/basic/currentstock?symbol=2330"
+        );
+    }
+
+    /// 驗證 serde 欄位對應：`trendPercentage` 需 rename，未列出的欄位要被忽略。
+    #[test]
+    fn response_deserializes_official_shape() {
+        let response: Response = serde_json::from_str(SUCCESS_BODY).unwrap();
+
+        assert_eq!(response.status, 0);
+        assert_eq!(response.data.deal, 1435.0);
+        assert_eq!(response.data.trend, -15.0);
+        assert_eq!(response.data.trend_percentage, -1.03);
+    }
+
+    /// `status` 為 0 時應原樣取出報價資料。
+    #[test]
+    fn parse_response_returns_data_when_status_is_zero() {
+        let response: Response = serde_json::from_str(SUCCESS_BODY).unwrap();
+        let data = parse_response("https://example.test", response).unwrap();
+
+        assert_eq!(data.deal, 1435.0);
+        assert_eq!(data.trend, -15.0);
+        assert_eq!(data.trend_percentage, -1.03);
+    }
+
+    /// `status` 非 0 代表來源回報失敗，必須報錯而不是回傳資料。
+    #[test]
+    fn parse_response_rejects_non_zero_status() {
+        let body =
+            r#"{ "status": 999, "data": { "deal": 0.0, "trend": 0.0, "trendPercentage": 0.0 } }"#;
+        let response: Response = serde_json::from_str(body).unwrap();
+        let err = parse_response("https://example.test/quote", response)
+            .expect_err("non-zero status should be an error");
+
+        assert!(err.to_string().contains("status is 999"));
+        assert!(err.to_string().contains("https://example.test/quote"));
+    }
 
     #[tokio::test]
     #[ignore]

--- a/src/infra/database/repository/portfolio.rs
+++ b/src/infra/database/repository/portfolio.rs
@@ -123,6 +123,10 @@ impl PortfolioRepository for PgPortfolioRepository {
     }
 
     /// 儲存持股年度已領股利總計及其各配發宣告項目。
+    ///
+    /// 寫入採覆蓋語意：除了新增或更新 `items` 之外，同一筆交易內還會清掉
+    /// 「掛在其他年度總表的同一次除息」、「本年度已不再適用」與「年度總表已被刪除」
+    /// 三種殘留明細，確保 `dividend_record_detail_more` 對每筆持股的每次除息只有一列。
     async fn save_received_dividend(
         &self,
         summary: &ReceivedDividend,
@@ -158,8 +162,25 @@ impl PortfolioRepository for PgPortfolioRepository {
             .context("Failed to save received dividend summary")?;
 
         let record_detail_serial = row.0;
+        let dividend_serials: Vec<i64> = items.iter().map(|item| item.dividend_serial).collect();
 
-        // 2. 寫入或更新配發細項 (dividend_record_detail_more)
+        // 2. 同一筆持股的同一次除息只能歸屬於一個年度總表。
+        // 股利的發放年度事後被更正時，先移除掛在其他年度底下的舊明細，避免同一次除息被重複計算。
+        let sql_delete_other_years = r#"
+            DELETE FROM dividend_record_detail_more
+            WHERE stock_ownership_details_serial = $1
+              AND dividend_record_detail_serial <> $2
+              AND dividend_serial = ANY($3);
+        "#;
+        sqlx::query(sql_delete_other_years)
+            .bind(summary.stock_ownership_details_serial)
+            .bind(record_detail_serial)
+            .bind(&dividend_serials)
+            .execute(&mut *tx)
+            .await
+            .context("Failed to delete received dividend items from other years")?;
+
+        // 3. 寫入或更新配發細項 (dividend_record_detail_more)
         let sql_item = r#"
             INSERT INTO dividend_record_detail_more (
                 stock_ownership_details_serial, dividend_record_detail_serial, dividend_serial,
@@ -188,6 +209,39 @@ impl PortfolioRepository for PgPortfolioRepository {
                 .await
                 .context("Failed to save received dividend item")?;
         }
+
+        // 4. 清掉本次重算後已不適用的舊明細。
+        // 股利金額被更正、持有日調整而失去領取資格等情況都會讓某筆除息不再列入，
+        // 只做 upsert 的話舊明細會殘留，導致明細加總與年度總表對不起來。
+        let sql_delete_stale = r#"
+            DELETE FROM dividend_record_detail_more
+            WHERE stock_ownership_details_serial = $1
+              AND dividend_record_detail_serial = $2
+              AND dividend_serial <> ALL($3);
+        "#;
+        sqlx::query(sql_delete_stale)
+            .bind(summary.stock_ownership_details_serial)
+            .bind(record_detail_serial)
+            .bind(&dividend_serials)
+            .execute(&mut *tx)
+            .await
+            .context("Failed to delete stale received dividend items")?;
+
+        // 5. 清掉年度總表已被刪除卻殘留的孤兒明細。
+        let sql_delete_orphan = r#"
+            DELETE FROM dividend_record_detail_more AS m
+            WHERE m.stock_ownership_details_serial = $1
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM dividend_record_detail AS d
+                  WHERE d.serial = m.dividend_record_detail_serial
+              );
+        "#;
+        sqlx::query(sql_delete_orphan)
+            .bind(summary.stock_ownership_details_serial)
+            .execute(&mut *tx)
+            .await
+            .context("Failed to delete orphaned received dividend items")?;
 
         tx.commit().await?;
         Ok(())


### PR DESCRIPTION
- Added logic to clean residual details:
  - Remove duplicate dividend records across different annual summaries.
  - Delete stale records no longer applicable after recalculations.
  - Purge orphaned records for deleted annual summaries.
- Adjusted insert/update behavior to maintain accurate mappings between stock ownership and dividends.